### PR TITLE
PowerShell 7.2 req, interactive login timeout, token cache support

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -1,0 +1,22 @@
+name: Run tests
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Pester
+      run: Install-Module -Name Pester -Force
+      shell: pwsh
+    - name: Run tests
+      run: .\Tests\TestRunner.ps1 -TestResults -Verbosity Normal
+      shell: pwsh
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v2
+      continue-on-error: true
+      with:
+        files: testResults.xml

--- a/.github/workflows/requireLabels.yml
+++ b/.github/workflows/requireLabels.yml
@@ -1,0 +1,13 @@
+name: Require Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v4
+        with:
+          mode: minimum
+          count: 1
+          labels: "bug, enhancement, documentation"

--- a/Docs/Help/Get-AzToken.md
+++ b/Docs/Help/Get-AzToken.md
@@ -19,10 +19,17 @@ Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-
  [<CommonParameters>]
 ```
 
+### Cache
+```
+Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
+ -TokenCache <String> [-Username <String>] [<CommonParameters>]
+```
+
 ### Interactive
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-Interactive] [-Force] [<CommonParameters>]
+ [-ClientId <String>] [-TokenCache <String>] [-TimeoutSeconds <Int32>] [-Interactive] [-Force]
+ [<CommonParameters>]
 ```
 
 ### ManagedIdentity
@@ -35,7 +42,7 @@ Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-
 
 Gets a new Azure access token.
 
-If the command is used non-interactively, an attempt will be made to get a token using the following sources in order:
+The token can be retrieved from an existing named cache, interactively from a browser, or non-interactively with specific token sources. If the command is used non-interactively, an attempt will be made to get a token using the following sources in order:
 
 - Saved interactive credential if the command was used interactively in the same session (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential)
 - Environment variables (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential)
@@ -43,6 +50,7 @@ If the command is used non-interactively, an attempt will be made to get a token
 - Azure CLI (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential)
 - Visual Studio Code (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocodecredential)
 - Visual Studio (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential)
+- Shared token cache (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential)
 
 ## EXAMPLES
 
@@ -63,6 +71,22 @@ PS C:\> Get-AzToken -Resource 'https://graph.microsoft.com/' -Scope 'User.Read',
 Gets a new Azure access token interactively for Microsoft Graph with the scopes `User.Read` and `LearningContent.Read.All`, also specifying a client id.
 
 ### Example 3
+
+```powershell
+PS C:\> Get-AzToken -Interactive -TokenCache 'AzAuthCache'
+```
+
+Gets a new Azure access token interactively and stores the token in a new (or existing) token cache named "AzAuthCache".
+
+### Example 4
+
+```powershell
+PS C:\> Get-AzToken -TokenCache 'AzAuthCache'
+```
+
+Gets a new Azure access token interactively from an existing token cache named "AzAuthCache".
+
+### Example 5
 
 ```powershell
 PS C:\> Get-AzToken -Scope 'Directory.Read.All' -ClientId '0b279d62-06f2-4175-b008-d9efd0e4f4d3' -ManagedIdentity
@@ -112,7 +136,7 @@ This may be required when combining interactive and non-interactive authenticati
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: NonInteractive, Interactive, ManagedIdentity
 Aliases:
 
 Required: False
@@ -199,6 +223,66 @@ The id of the tenant that the token should be valid for.
 ```yaml
 Type: String
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutSeconds
+
+The number of seconds to wait until the interactive login times out.
+
+```yaml
+Type: Int32
+Parameter Sets: Interactive
+Aliases:
+
+Required: False
+Position: Named
+Default value: 120
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenCache
+
+The name of the token cache to get the token from, or to store the interactively retrieved token in.
+
+```yaml
+Type: String
+Parameter Sets: Cache
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: Interactive
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+
+The username to get the token for in the named cache.
+
+```yaml
+Type: String
+Parameter Sets: Cache
 Aliases:
 
 Required: False

--- a/Source/AzAuth.Core/AzAuth.Core.csproj
+++ b/Source/AzAuth.Core/AzAuth.Core.csproj
@@ -1,24 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
-        <DebugSymbols>false</DebugSymbols>
-        <DebugType>None</DebugType>
-        <GenerateDependencyFile>false</GenerateDependencyFile>
-        <RootNamespace>PipeHow.$(MSBuildProjectName.Replace(" ", "_").TrimEnd(".Core"))</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <RootNamespace>PipeHow.$(MSBuildProjectName.Replace(" ", "_").TrimEnd(".Core"))</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-	    <PackageReference Include="Azure.Identity" Version="1.8.2" />
-	    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.29.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Models\" />
-    </ItemGroup>
+  <ItemGroup>
+	  <PackageReference Include="Azure.Identity" Version="1.8.2" />
+	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.0" />
+	  <PackageReference Include="System.Management.Automation" Version="7.2.11" />
+	  <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+  </ItemGroup>
 
 </Project>

--- a/Source/AzAuth.PS/AzAuth.PS.csproj
+++ b/Source/AzAuth.PS/AzAuth.PS.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>None</DebugType>
     <GenerateDependencyFile>false</GenerateDependencyFile>
@@ -13,7 +14,6 @@
 	
   <ItemGroup>
     <ProjectReference Include="..\AzAuth.Core\AzAuth.Core.csproj" />
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="All" />
 	</ItemGroup>
 	

--- a/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
+++ b/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
@@ -7,33 +7,51 @@ namespace PipeHow.AzAuth
     public class GetAzToken : PSCmdlet
     {
         [Parameter(ParameterSetName = "NonInteractive", Position = 0)]
+        [Parameter(ParameterSetName = "Cache", Position = 0)]
         [Parameter(ParameterSetName = "Interactive", Position = 0)]
         [Parameter(ParameterSetName = "ManagedIdentity", Position = 0)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         [Alias("ResourceId", "ResourceUrl")]
         public string Resource { get; set; } = "https://graph.microsoft.com";
 
         [Parameter(ParameterSetName = "NonInteractive", Position = 1)]
+        [Parameter(ParameterSetName = "Cache", Position = 1)]
         [Parameter(ParameterSetName = "Interactive", Position = 1)]
         [Parameter(ParameterSetName = "ManagedIdentity", Position = 1)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string[] Scope { get; set; } = new[] { ".default" };
 
         [Parameter(ParameterSetName = "NonInteractive")]
+        [Parameter(ParameterSetName = "Cache")]
         [Parameter(ParameterSetName = "Interactive")]
         [Parameter(ParameterSetName = "ManagedIdentity")]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string TenantId { get; set; }
 
         [Parameter(ParameterSetName = "NonInteractive")]
+        [Parameter(ParameterSetName = "Cache")]
         [Parameter(ParameterSetName = "Interactive")]
         [Parameter(ParameterSetName = "ManagedIdentity")]
-        [ValidateNotNullOrEmpty()]
+        [ValidateNotNullOrEmpty]
         public string Claim { get; set; }
 
         [Parameter(ParameterSetName = "Interactive")]
         [Parameter(ParameterSetName = "ManagedIdentity")]
+        [ValidateNotNullOrEmpty]
         public string ClientId { get; set; }
+
+        [Parameter(ParameterSetName = "Interactive")]
+        [Parameter(Mandatory = true, ParameterSetName = "Cache")]
+        [ValidateNotNullOrEmpty]
+        public string TokenCache { get; set; }
+
+        [Parameter(ParameterSetName = "Cache")]
+        [ValidateNotNullOrEmpty]
+        public string Username { get; set; }
+
+        [Parameter(ParameterSetName = "Interactive")]
+        [ValidateRange(1, int.MaxValue)]
+        public int TimeoutSeconds { get; set; } = 120;
 
         [Parameter(Mandatory = true, ParameterSetName = "Interactive")]
         public SwitchParameter Interactive { get; set; }
@@ -72,13 +90,19 @@ Azure PowerShell (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.az
 Azure CLI (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential)
 Visual Studio Code (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocodecredential)
 Visual Studio (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential)
+Shared token cache (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential)
 ");
                 WriteObject(TokenManager.GetTokenNonInteractive(Resource, Scope, Claim, TenantId, cancellationTokenSource.Token));
+            }
+            else if (ParameterSetName == "Cache")
+            {
+                WriteVerbose($"Getting token from token cache named \"{TokenCache}\" (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential).");
+                WriteObject(TokenManager.GetTokenFromCache(Resource, Scope, Claim, TenantId, TokenCache, Username, cancellationTokenSource.Token));
             }
             else if (Interactive.IsPresent)
             {
                 WriteVerbose("Getting token interactively using the default browser (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential).");
-                WriteObject(TokenManager.GetTokenInteractive(Resource, Scope, Claim, ClientId, TenantId, cancellationTokenSource.Token));
+                WriteObject(TokenManager.GetTokenInteractive(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, cancellationTokenSource.Token));
             }
             else if (ManagedIdentity.IsPresent)
             {

--- a/Source/AzAuth.PS/Manifest/AzAuth.psd1
+++ b/Source/AzAuth.PS/Manifest/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.0.1'
+ModuleVersion = '2.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -25,7 +25,7 @@ Copyright = '(c) Emanuel Palm. All rights reserved.'
 Description = 'A lightweight PowerShell module to handle Azure authentication, using the Azure.Identity MSAL library.'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '7.0'
+PowerShellVersion = '7.2'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/Tests/Get-AzToken.Tests.ps1
+++ b/Tests/Get-AzToken.Tests.ps1
@@ -14,6 +14,7 @@ BeforeDiscovery {
             Type          = 'string'
             ParameterSets = @(
                 @{ Name = 'NonInteractive'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
             )
@@ -23,6 +24,7 @@ BeforeDiscovery {
             Type          = 'string[]'
             ParameterSets = @(
                 @{ Name = 'NonInteractive'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
             )
@@ -32,6 +34,7 @@ BeforeDiscovery {
             Type          = 'string'
             ParameterSets = @(
                 @{ Name = 'NonInteractive'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
             )
@@ -41,6 +44,7 @@ BeforeDiscovery {
             Type          = 'string'
             ParameterSets = @(
                 @{ Name = 'NonInteractive'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
             )
@@ -51,6 +55,28 @@ BeforeDiscovery {
             ParameterSets = @(
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+            )
+        }
+        @{
+            Name          = 'TokenCache'
+            Type          = 'string'
+            ParameterSets = @(
+                @{ Name = 'Interactive'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $true }
+            )
+        }
+        @{
+            Name          = 'Username'
+            Type          = 'string'
+            ParameterSets = @(
+                @{ Name = 'Cache'; Mandatory = $false }
+            )
+        }
+        @{
+            Name          = 'TimeoutSeconds'
+            Type          = 'int'
+            ParameterSets = @(
+                @{ Name = 'Interactive'; Mandatory = $false }
             )
         }
         @{

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,9 @@ param(
 
     [string]
     $Version,
+    
+    [string]
+    $DotNetVersion = 'net6.0',
 
     [Switch]
     $NoClean
@@ -13,7 +16,6 @@ param(
 Push-Location 'Source'
 
 $ModuleName = Get-ChildItem -Recurse "$PSScriptRoot\Source\*.psd1" | Select-Object -ExpandProperty BaseName
-$DotNetVersion = 'netstandard2.0'
 
 # Define build output locations
 $OutDir = "$PSScriptRoot\$ModuleName"


### PR DESCRIPTION
Bump to LTS versions .NET 6 and PowerShell 7.2.

Adds support for token cache, and adds configurable timeout of 120 seconds by default for interactive login.

Solves:
- #10 
- #12