### PR TITLE
Improved cache, `Clear-AzTokenCache`, version 2.2.2

### DIFF
--- a/Docs/Help/Clear-AzTokenCache.md
+++ b/Docs/Help/Clear-AzTokenCache.md
@@ -1,0 +1,65 @@
+---
+external help file: AzAuth.PS.dll-Help.xml
+Module Name: AzAuth
+online version:
+schema: 2.0.0
+---
+
+# Clear-AzTokenCache
+
+## SYNOPSIS
+
+Clear all tokens from a specified token cache.
+
+## SYNTAX
+
+```
+Clear-AzTokenCache -TokenCache <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Clear all tokens from a specified token cache. The file may remain on disk, but without any tokens.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Clear-AzTokenCache -TokenCache 'MyCache'
+```
+
+Clears all tokens from the cache named "MyCache".
+
+## PARAMETERS
+
+### -TokenCache
+
+The name of the token cache to clear.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Get-AzToken.md
+++ b/Docs/Help/Get-AzToken.md
@@ -22,7 +22,7 @@ Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-
 ### Cache
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- -TokenCache <String> [-Username <String>] [<CommonParameters>]
+ [-ClientId <String>] -TokenCache <String> -Username <String> [<CommonParameters>]
 ```
 
 ### Interactive
@@ -125,7 +125,7 @@ The client id of the application used to authenticate the user or identity. If n
 
 ```yaml
 Type: String
-Parameter Sets: Interactive, DeviceCode, ManagedIdentity
+Parameter Sets: Cache, Interactive, DeviceCode, ManagedIdentity
 Aliases:
 
 Required: False
@@ -308,7 +308,7 @@ Type: String
 Parameter Sets: Cache
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Source/AzAuth.Core/CacheManager.cs
+++ b/Source/AzAuth.Core/CacheManager.cs
@@ -1,0 +1,203 @@
+﻿using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Extensions.Msal;
+using Microsoft.VisualStudio.Threading;
+using System.Collections.Concurrent;
+using System.Threading;
+using static System.Formats.Asn1.AsnWriter;
+
+namespace PipeHow.AzAuth;
+
+internal static class CacheManager
+{
+    private static MsalCacheHelper? cacheHelper;
+    private static IPublicClientApplication? application;
+    private static readonly JoinableTaskFactory taskFactory = new(new JoinableTaskContext());
+
+    // This is the well-known client id for the public Azure CLI client app
+    private const string AzureCliClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
+
+    private static async Task InitializeCacheManagerAsync(string cacheName, string? clientId, string? tenantId, CancellationToken cancellationToken)
+    {
+        // This is the directory where MSAL stores its cache by default
+        var cacheDir = $"{MsalCacheHelper.UserRootDirectory}/.IdentityService/{cacheName}";
+        
+        var storageProperties = new StorageCreationPropertiesBuilder(cacheName, cacheDir)
+            .WithMacKeyChain("PipeHow.AzAuth", cacheName)
+            .WithLinuxKeyring(cacheName, MsalCacheHelper.LinuxKeyRingDefaultCollection, "AzAuthTokenCache",
+                new KeyValuePair<string, string>("Product", "PipeHow.AzAuth"),
+                new KeyValuePair<string, string>("PipeHow.AzAuth", "1.0.0.0"))
+            .Build();
+
+        // Task.Run to use cancellationToken
+        cacheHelper = await Task.Run(() => MsalCacheHelper.CreateAsync(storageProperties), cancellationToken);
+
+        application = PublicClientApplicationBuilder.Create(clientId ?? AzureCliClientId)
+           .WithAuthority(AzureCloudInstance.AzurePublic, tenantId ?? "organizations") // Use tenant if available, otherwise personal accounts break
+           .WithDefaultRedirectUri() // http://localhost on .NET core
+           .Build();
+
+        cacheHelper.RegisterCache(application.UserTokenCache);
+        cacheHelper.VerifyPersistence();
+    }
+
+    /// <summary>
+    /// Creates a token cache and registers it on disk.
+    /// </summary>
+    internal static void CreateCacheIfNotExists(string cacheName, string? clientId, string? tenantId, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => CreateCacheIfNotExistsAsync(cacheName, clientId, tenantId, cancellationToken));
+
+    internal static async Task CreateCacheIfNotExistsAsync(string cacheName, string? clientId, string? tenantId, CancellationToken cancellationToken)
+    {
+        await InitializeCacheManagerAsync(cacheName, clientId, tenantId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Get an access token interactively.
+    /// </summary>
+    internal static AzToken GetTokenInteractive(string cacheName, string? clientId, string? tenantId, IEnumerable<string> scopes, string? claims, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => GetTokenInteractiveAsync(cacheName, clientId, tenantId, scopes, claims, cancellationToken));
+
+    internal static async Task<AzToken> GetTokenInteractiveAsync(
+        string cacheName,
+        string? clientId,
+        string? tenantId,
+        IEnumerable<string> scopes,
+        string? claims,
+        CancellationToken cancellationToken)
+    {
+        await InitializeCacheManagerAsync(cacheName, clientId, tenantId, cancellationToken);
+
+        var tokenBuilder = application!.AcquireTokenInteractive(scopes);
+
+        if (!string.IsNullOrWhiteSpace(claims))
+        {
+            tokenBuilder = tokenBuilder.WithClaims(claims);
+        }
+
+        var result = await tokenBuilder.ExecuteAsync(cancellationToken);
+
+        return new AzToken(
+            result.AccessToken,
+            result.Scopes.ToArray(),
+            result.ExpiresOn,
+            result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
+            result.TenantId
+        );
+    }
+
+    /// <summary>
+    /// Get an access token using a device code.
+    /// </summary>
+    internal static AzToken GetTokenDeviceCode(string cacheName, string? clientId, string? tenantId, IEnumerable<string> scopes, string? claims, BlockingCollection<string> loggingQueue, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => GetTokenDeviceCodeAsync(cacheName, clientId, tenantId, scopes, claims, loggingQueue, cancellationToken));
+
+    internal static async Task<AzToken> GetTokenDeviceCodeAsync(
+        string cacheName,
+        string? clientId,
+        string? tenantId,
+        IEnumerable<string> scopes,
+        string? claims,
+        BlockingCollection<string> loggingQueue,
+        CancellationToken cancellationToken)
+    {
+        await InitializeCacheManagerAsync(cacheName, clientId, tenantId, cancellationToken);
+
+        var tokenBuilder = application!.AcquireTokenWithDeviceCode(
+            scopes,
+            deviceCodeInfo =>
+                Task.Run(() => {
+                    loggingQueue.Add(deviceCodeInfo.Message, cancellationToken);
+                    // Make sure to mark as completed, no more messages can be sent
+                    loggingQueue.CompleteAdding();
+                }, cancellationToken)
+            );
+
+        if (!string.IsNullOrWhiteSpace(claims))
+        {
+            tokenBuilder = tokenBuilder.WithClaims(claims);
+        }
+
+        var result = await tokenBuilder.ExecuteAsync(cancellationToken);
+
+        return new AzToken(
+            result.AccessToken,
+            result.Scopes.ToArray(),
+            result.ExpiresOn,
+            result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
+            result.TenantId
+        );
+    }
+
+    /// <summary>
+    /// Get an access token silently from existing cache.
+    /// </summary>
+    internal static void GetTokenFromCacheSilent(string cacheName, string? clientId, string? tenantId, IEnumerable<string> scopes, string? claims, string username, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => GetTokenFromCacheSilentAsync(cacheName, clientId, tenantId, scopes, claims, username, cancellationToken));
+
+    internal static async Task<AzToken> GetTokenFromCacheSilentAsync(
+        string cacheName,
+        string? clientId,
+        string? tenantId,
+        IEnumerable<string> scopes,
+        string? claims,
+        string username,
+        CancellationToken cancellationToken)
+    {
+        await InitializeCacheManagerAsync(cacheName, clientId, tenantId, cancellationToken);
+
+        var tokenBuilder = application!.AcquireTokenSilent(scopes, username);
+
+        if (!string.IsNullOrWhiteSpace(claims))
+        {
+            tokenBuilder = tokenBuilder.WithClaims(claims);
+        }
+
+        var result = await tokenBuilder.ExecuteAsync(cancellationToken);
+
+        return new AzToken(
+            result.AccessToken,
+            result.Scopes.ToArray(),
+            result.ExpiresOn,
+            result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
+            result.TenantId
+        );
+    }
+
+    /// <summary>
+    /// Clears an existing cache and unregisters it from disk. The file may remain without tokens.
+    /// </summary>
+    internal static void ClearCache(string cacheName, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => ClearCacheAsync(cacheName, cancellationToken));
+
+    internal static async Task ClearCacheAsync(string cacheName, CancellationToken cancellationToken)
+    {
+        await InitializeCacheManagerAsync(cacheName, null, null, cancellationToken);
+
+        // Remove all accounts from cache async
+        var accounts = await application!.GetAccountsAsync();
+
+        // Task.Run to allow cancellationToken
+        await Task.Run(() => Task.WhenAll(accounts.Select(application.RemoveAsync)), cancellationToken);
+
+        // Unregister cache
+        cacheHelper!.UnregisterCache(application.UserTokenCache);
+    }
+
+    internal static string[] GetAccounts(string? cacheName, CancellationToken cancellationToken = default) =>
+        taskFactory.Run(() => GetAccountsAsync(cacheName, cancellationToken));
+
+    private static async Task<string[]> GetAccountsAsync(string? cacheName, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(cacheName))
+        {
+            await InitializeCacheManagerAsync(cacheName, null, null, cancellationToken);
+        }
+        else
+        {
+            throw new ArgumentNullException("cacheName", "Cache handling could not be initialized!");
+        }
+
+        var accounts = await application!.GetAccountsAsync();
+        return accounts.Select(a => a.Username ?? a.HomeAccountId.ObjectId).ToArray();
+    }
+}

--- a/Source/AzAuth.Core/TokenManager.cs
+++ b/Source/AzAuth.Core/TokenManager.cs
@@ -104,13 +104,20 @@ internal static class TokenManager
         CancellationToken cancellationToken)
     {
         var fullScopes = scopes.Select(s => $"{resource.TrimEnd('/')}/{s}").ToArray();
-        
+
         if (string.IsNullOrWhiteSpace(tokenCache))
         {
             throw new ArgumentNullException(nameof(tokenCache), "The specified token cache cannot be null or empty!");
         }
 
-        return await CacheManager.GetTokenFromCacheSilentAsync(tokenCache, clientId, tenantId, fullScopes, claims, username, cancellationToken);
+        try
+        {
+            return await CacheManager.GetTokenFromCacheSilentAsync(tokenCache, clientId, tenantId, fullScopes, claims, username, cancellationToken);
+        }
+        catch (MsalServiceException ex) when (ex.Message.Contains("Please do not use the /consumers endpoint to serve this request."))
+        {
+            throw new InvalidOperationException("The account used is a personal account and cannot use a general endpoint. Please specify the tenant using the parameter -TenantId.", ex);
+        }
     }
 
     /// <summary>

--- a/Source/AzAuth.Core/TokenManager.cs
+++ b/Source/AzAuth.Core/TokenManager.cs
@@ -1,6 +1,8 @@
 ﻿using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client.Extensions.Msal;
+using Microsoft.Identity.Client;
 using Microsoft.VisualStudio.Threading;
 using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
@@ -8,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace PipeHow.AzAuth;
 
-public static class TokenManager
+internal static class TokenManager
 {
     private static TokenCredential? credential;
     private static string? previousTenantId;
@@ -20,13 +22,13 @@ public static class TokenManager
     /// <summary>
     /// Gets token noninteractively.
     /// </summary>
-    public static AzToken GetTokenNonInteractive(string resource, string[] scopes, string? claims, string? tenantId, CancellationToken cancellationToken) =>
+    internal static AzToken GetTokenNonInteractive(string resource, string[] scopes, string? claims, string? tenantId, CancellationToken cancellationToken) =>
         taskFactory.Run(() => GetTokenNonInteractiveAsync(resource, scopes, claims, tenantId, cancellationToken));
 
     /// <summary>
     /// Gets token noninteractively.
     /// </summary>
-    public static async Task<AzToken> GetTokenNonInteractiveAsync(
+    internal static async Task<AzToken> GetTokenNonInteractiveAsync(
         string resource,
         string[] scopes,
         string? claims,
@@ -85,48 +87,42 @@ public static class TokenManager
     /// <summary>
     /// Gets token noninteractively from existing named token cache.
     /// </summary>
-    public static AzToken GetTokenFromCache(string resource, string[] scopes, string? claims, string? tenantId, string tokenCache, string? username, CancellationToken cancellationToken) =>
-        taskFactory.Run(() => GetTokenFromCacheAsync(resource, scopes, claims, tenantId, tokenCache, username, cancellationToken));
+    internal static AzToken GetTokenFromCache(string resource, string[] scopes, string? claims, string? clientId, string? tenantId, string tokenCache, string username, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => GetTokenFromCacheAsync(resource, scopes, claims, clientId, tenantId, tokenCache, username, cancellationToken));
 
     /// <summary>
     /// Gets token noninteractively from existing named token cache.
     /// </summary>
-    public static async Task<AzToken> GetTokenFromCacheAsync(
+    internal static async Task<AzToken> GetTokenFromCacheAsync(
         string resource,
         string[] scopes,
         string? claims,
+        string? clientId,
         string? tenantId,
         string tokenCache,
-        string? username,
+        string username,
         CancellationToken cancellationToken)
     {
         var fullScopes = scopes.Select(s => $"{resource.TrimEnd('/')}/{s}").ToArray();
-
+        
         if (string.IsNullOrWhiteSpace(tokenCache))
         {
             throw new ArgumentNullException(nameof(tokenCache), "The specified token cache cannot be null or empty!");
         }
 
-        var options = new SharedTokenCacheCredentialOptions(new TokenCachePersistenceOptions { Name = tokenCache }) {
-            Username = username
-        };
-
-        credential = new SharedTokenCacheCredential(options);
-
-        var tokenRequestContext = new TokenRequestContext(fullScopes, null, claims, tenantId);
-        return await GetTokenAsync(tokenRequestContext, cancellationToken);
+        return await CacheManager.GetTokenFromCacheSilentAsync(tokenCache, clientId, tenantId, fullScopes, claims, username, cancellationToken);
     }
 
     /// <summary>
     /// Gets token interactively.
     /// </summary>
-    public static AzToken GetTokenInteractive(string resource, string[] scopes, string? claims, string? clientId, string? tenantId, string tokenCache, int timeoutSeconds, CancellationToken cancellationToken) =>
+    internal static AzToken GetTokenInteractive(string resource, string[] scopes, string? claims, string? clientId, string? tenantId, string? tokenCache, int timeoutSeconds, CancellationToken cancellationToken) =>
         taskFactory.Run(() => GetTokenInteractiveAsync(resource, scopes, claims, clientId, tenantId, tokenCache, timeoutSeconds, cancellationToken));
 
     /// <summary>
     /// Gets token interactively.
     /// </summary>
-    public static async Task<AzToken> GetTokenInteractiveAsync(
+    internal static async Task<AzToken> GetTokenInteractiveAsync(
         string resource,
         string[] scopes,
         string? claims,
@@ -139,14 +135,13 @@ public static class TokenManager
         var fullScopes = scopes.Select(s => $"{resource.TrimEnd('/')}/{s}").ToArray();
         var tokenRequestContext = new TokenRequestContext(fullScopes, null, claims, tenantId);
 
-        var options = new InteractiveBrowserCredentialOptions()
+        if (!string.IsNullOrWhiteSpace(tokenCache))
         {
-            TokenCachePersistenceOptions = tokenCache is not null ? new TokenCachePersistenceOptions { Name = tokenCache } : null,
-            ClientId = clientId
-        };
+            return CacheManager.GetTokenInteractive(tokenCache, clientId, tenantId, fullScopes, claims, cancellationToken);
+        }
 
         // Create a new credential
-        credential = new InteractiveBrowserCredential(options);
+        credential = new InteractiveBrowserCredential();
 
         try
         {
@@ -165,7 +160,7 @@ public static class TokenManager
     /// <summary>
     /// Gets token using a device code.
     /// </summary>
-    public static async Task<AzToken> GetTokenDeviceCodeAsync(
+    internal static async Task<AzToken> GetTokenDeviceCodeAsync(
         string resource,
         string[] scopes,
         string? claims,
@@ -179,6 +174,15 @@ public static class TokenManager
         var fullScopes = scopes.Select(s => $"{resource.TrimEnd('/')}/{s}").ToArray();
         var tokenRequestContext = new TokenRequestContext(fullScopes, null, claims, tenantId);
 
+        // If user specified a cache name, get token using cache manager
+        if (tokenCache != null)
+        {
+            // Create a new cancellation token by combining a timeout with existing token
+            using var timeoutSource = new CancellationTokenSource(timeoutSeconds * 1000);
+            var combinedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutSource.Token).Token;
+            return await CacheManager.GetTokenDeviceCodeAsync(tokenCache, clientId, tenantId, fullScopes, claims, loggingQueue, combinedToken);
+        }
+
         var options = new DeviceCodeCredentialOptions
         {
             // Register message in collection for Cmdlet to process
@@ -188,7 +192,6 @@ public static class TokenManager
                     // Make sure to mark as completed, no more messages can be sent
                     loggingQueue.CompleteAdding();
                 }, cancellationToken),
-            TokenCachePersistenceOptions = tokenCache is not null ? new TokenCachePersistenceOptions { Name = tokenCache } : null,
             ClientId = clientId
         };
 
@@ -216,13 +219,13 @@ public static class TokenManager
     /// <summary>
     /// Gets token as a managed identity.
     /// </summary>
-    public static AzToken GetTokenManagedIdentity(string resource, string[] scopes, string? claims, string? clientId, string? tenantId, CancellationToken cancellationToken) =>
+    internal static AzToken GetTokenManagedIdentity(string resource, string[] scopes, string? claims, string? clientId, string? tenantId, CancellationToken cancellationToken) =>
         taskFactory.Run(() => GetTokenManagedIdentityAsync(resource, scopes, claims, clientId, tenantId, cancellationToken));
 
     /// <summary>
     /// Gets token as a managed identity.
     /// </summary>
-    public static async Task<AzToken> GetTokenManagedIdentityAsync(
+    internal static async Task<AzToken> GetTokenManagedIdentityAsync(
         string resource,
         string[] scopes,
         string? claims,
@@ -245,7 +248,7 @@ public static class TokenManager
     }
 
     // Common method for getting the token from the credential depending on the user's authentication method.
-    private static async Task<AzToken> GetTokenAsync(TokenRequestContext tokenRequestContext, CancellationToken cancellationToken)
+    internal static async Task<AzToken> GetTokenAsync(TokenRequestContext tokenRequestContext, CancellationToken cancellationToken)
     {
         if (credential is null)
         {
@@ -274,7 +277,7 @@ public static class TokenManager
         );
     }
 
-    public static void ClearCredential()
+    internal static void ClearCredential()
     {
         credential = null;
     }

--- a/Source/AzAuth.PS/Cmdlets/ClearAzTokenCache.cs
+++ b/Source/AzAuth.PS/Cmdlets/ClearAzTokenCache.cs
@@ -1,0 +1,21 @@
+﻿using System.Management.Automation;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+namespace PipeHow.AzAuth.Cmdlets;
+
+[Cmdlet(VerbsCommon.Clear, "AzTokenCache")]
+public class ClearAzTokenCache : PSLoggerCmdletBase
+{
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string TokenCache { get; set; }
+
+    protected override void EndProcessing()
+    {
+        if (TokenCache == "msal.cache")
+        {
+            WriteWarning("The name 'msal.cache' is the default cache name in MSAL, changing or clearing this cache might break other tools using it!");
+        }
+        CacheManager.ClearCache(TokenCache, stopProcessing.Token);
+    }
+}

--- a/Source/AzAuth.PS/Cmdlets/ExistingAccounts.cs
+++ b/Source/AzAuth.PS/Cmdlets/ExistingAccounts.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PipeHow.AzAuth;
+
+public class ExistingAccounts : IArgumentCompleter
+{
+    public IEnumerable<CompletionResult> CompleteArgument(
+        string commandName,
+        string parameterName,
+        string wordToComplete,
+        CommandAst commandAst,
+        IDictionary fakeBoundParameters)
+    {
+        IEnumerable<CompletionResult> results = Enumerable.Empty<CompletionResult>();
+
+        try
+        {
+            return CacheManager.GetAccounts(fakeBoundParameters["TokenCache"]?.ToString()).Select(a => new CompletionResult(a));
+        }
+        catch (Exception) { /* It's fine if we cannot get accounts here */ }
+
+        return results;
+    }
+}

--- a/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
+++ b/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
@@ -92,13 +92,9 @@ public class GetAzToken : PSLoggerCmdletBase
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD104:Offer async methods", Justification = "PowerShell doesn't handle async.")]
     protected override void EndProcessing()
     {
-        if (TokenCache != null)
+        if (TokenCache == "msal.cache")
         {
-            if (TokenCache == "msal.cache")
-            {
-                WriteWarning("The name 'msal.cache' is the default cache name in MSAL, changing or clearing this cache might break other tools using it!");
-            }
-            WriteWarning($"Number of accounts in cache: {CacheManager.GetAccounts(TokenCache).Length}");
+            WriteWarning("The name 'msal.cache' is the default cache name in MSAL, changing or clearing this cache might break other tools using it!");
         }
 
         WriteVerbose($"Getting token for {Resource} with scopes: {string.Join(", ", Scope)}.");
@@ -117,18 +113,18 @@ Shared token cache (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.
         }
         else if (ParameterSetName == "Cache")
         {
-            WriteVerbose($"Getting token from token cache named \"{TokenCache}\" (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential).");
+            WriteVerbose($"Getting token from token cache named \"{TokenCache}\".");
             WriteObject(TokenManager.GetTokenFromCache(Resource, Scope, Claim, ClientId, TenantId, TokenCache!, Username, stopProcessing.Token));
         }
         else if (Interactive.IsPresent)
         {
-            WriteVerbose("Getting token interactively using the default browser (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential).");
+            WriteVerbose("Getting token interactively using the default browser.");
             WriteObject(TokenManager.GetTokenInteractive(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, stopProcessing.Token));
         }
         else if (DeviceCode.IsPresent)
         {
-            WriteVerbose("Getting token using device code flow (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.devicecodecredential).");
-            
+            WriteVerbose("Getting token using the device code flow.");
+
             // Set up a BlockingCollection to use for logging device code message
             BlockingCollection<string> loggingQueue = new();
             // Start device code flow and save task
@@ -149,17 +145,12 @@ Shared token cache (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.
         }
         else if (ManagedIdentity.IsPresent)
         {
-            WriteVerbose("Getting token as managed identity (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential).");
+            WriteVerbose("Getting token using a managed identity (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential).");
             WriteObject(TokenManager.GetTokenManagedIdentity(Resource, Scope, Claim, ClientId, TenantId, stopProcessing.Token));
         }
         else
         {
             throw new ArgumentException("Invalid parameter combination!");
-        }
-
-        if (TokenCache != null)
-        {
-            WriteWarning($"Number of accounts in cache: {CacheManager.GetAccounts(TokenCache).Length}");
         }
     }
 }

--- a/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
+++ b/Source/AzAuth.PS/Cmdlets/GetAzToken.cs
@@ -1,101 +1,111 @@
-﻿using Microsoft.VisualStudio.Threading;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Management.Automation;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-namespace PipeHow.AzAuth
+namespace PipeHow.AzAuth;
+
+[Cmdlet(VerbsCommon.Get, "AzToken", DefaultParameterSetName = "NonInteractive")]
+public class GetAzToken : PSLoggerCmdletBase
 {
-    [Cmdlet(VerbsCommon.Get, "AzToken", DefaultParameterSetName = "NonInteractive")]
-    public class GetAzToken : PSLoggerCmdletBase
+    [Parameter(ParameterSetName = "NonInteractive", Position = 0)]
+    [Parameter(ParameterSetName = "Cache", Position = 0)]
+    [Parameter(ParameterSetName = "Interactive", Position = 0)]
+    [Parameter(ParameterSetName = "DeviceCode", Position = 0)]
+    [Parameter(ParameterSetName = "ManagedIdentity", Position = 0)]
+    [ValidateNotNullOrEmpty]
+    [Alias("ResourceId", "ResourceUrl")]
+    public string Resource { get; set; } = "https://graph.microsoft.com";
+
+    [Parameter(ParameterSetName = "NonInteractive", Position = 1)]
+    [Parameter(ParameterSetName = "Cache", Position = 1)]
+    [Parameter(ParameterSetName = "Interactive", Position = 1)]
+    [Parameter(ParameterSetName = "DeviceCode", Position = 1)]
+    [Parameter(ParameterSetName = "ManagedIdentity", Position = 1)]
+    [ValidateNotNullOrEmpty]
+    public string[] Scope { get; set; } = new[] { ".default" };
+
+    [Parameter(ParameterSetName = "NonInteractive")]
+    [Parameter(ParameterSetName = "Cache")]
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [Parameter(ParameterSetName = "ManagedIdentity")]
+    [ValidateNotNullOrEmpty]
+    public string TenantId { get; set; }
+
+    [Parameter(ParameterSetName = "NonInteractive")]
+    [Parameter(ParameterSetName = "Cache")]
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [Parameter(ParameterSetName = "ManagedIdentity")]
+    [ValidateNotNullOrEmpty]
+    public string Claim { get; set; }
+
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [Parameter(ParameterSetName = "ManagedIdentity")]
+    [Parameter(ParameterSetName = "Cache")]
+    [ValidateNotNullOrEmpty]
+    public string ClientId { get; set; }
+
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [Parameter(Mandatory = true, ParameterSetName = "Cache")]
+    [ValidateNotNullOrEmpty]
+    public string TokenCache { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Cache")]
+    [ValidateNotNullOrEmpty]
+    [ArgumentCompleter(typeof(ExistingAccounts))]
+    public string Username { get; set; }
+
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [ValidateRange(1, int.MaxValue)]
+    public int TimeoutSeconds { get; set; } = 120;
+
+    [Parameter(Mandatory = true, ParameterSetName = "Interactive")]
+    public SwitchParameter Interactive { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
+    public SwitchParameter DeviceCode { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "ManagedIdentity")]
+    public SwitchParameter ManagedIdentity { get; set; }
+
+    [Parameter(ParameterSetName = "NonInteractive")]
+    [Parameter(ParameterSetName = "Interactive")]
+    [Parameter(ParameterSetName = "DeviceCode")]
+    [Parameter(ParameterSetName = "ManagedIdentity")]
+    public SwitchParameter Force { get; set; }
+
+    // If user specifies Force, disregard earlier authentication
+    protected override void BeginProcessing()
     {
-        [Parameter(ParameterSetName = "NonInteractive", Position = 0)]
-        [Parameter(ParameterSetName = "Cache", Position = 0)]
-        [Parameter(ParameterSetName = "Interactive", Position = 0)]
-        [Parameter(ParameterSetName = "DeviceCode", Position = 0)]
-        [Parameter(ParameterSetName = "ManagedIdentity", Position = 0)]
-        [ValidateNotNullOrEmpty]
-        [Alias("ResourceId", "ResourceUrl")]
-        public string Resource { get; set; } = "https://graph.microsoft.com";
+        base.BeginProcessing();
 
-        [Parameter(ParameterSetName = "NonInteractive", Position = 1)]
-        [Parameter(ParameterSetName = "Cache", Position = 1)]
-        [Parameter(ParameterSetName = "Interactive", Position = 1)]
-        [Parameter(ParameterSetName = "DeviceCode", Position = 1)]
-        [Parameter(ParameterSetName = "ManagedIdentity", Position = 1)]
-        [ValidateNotNullOrEmpty]
-        public string[] Scope { get; set; } = new[] { ".default" };
-
-        [Parameter(ParameterSetName = "NonInteractive")]
-        [Parameter(ParameterSetName = "Cache")]
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [Parameter(ParameterSetName = "ManagedIdentity")]
-        [ValidateNotNullOrEmpty]
-        public string TenantId { get; set; }
-
-        [Parameter(ParameterSetName = "NonInteractive")]
-        [Parameter(ParameterSetName = "Cache")]
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [Parameter(ParameterSetName = "ManagedIdentity")]
-        [ValidateNotNullOrEmpty]
-        public string Claim { get; set; }
-
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [Parameter(ParameterSetName = "ManagedIdentity")]
-        [ValidateNotNullOrEmpty]
-        public string ClientId { get; set; }
-
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [Parameter(Mandatory = true, ParameterSetName = "Cache")]
-        [ValidateNotNullOrEmpty]
-        public string TokenCache { get; set; }
-
-        [Parameter(ParameterSetName = "Cache")]
-        [ValidateNotNullOrEmpty]
-        public string Username { get; set; }
-
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [ValidateRange(1, int.MaxValue)]
-        public int TimeoutSeconds { get; set; } = 120;
-
-        [Parameter(Mandatory = true, ParameterSetName = "Interactive")]
-        public SwitchParameter Interactive { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "DeviceCode")]
-        public SwitchParameter DeviceCode { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "ManagedIdentity")]
-        public SwitchParameter ManagedIdentity { get; set; }
-
-        [Parameter(ParameterSetName = "NonInteractive")]
-        [Parameter(ParameterSetName = "Interactive")]
-        [Parameter(ParameterSetName = "DeviceCode")]
-        [Parameter(ParameterSetName = "ManagedIdentity")]
-        public SwitchParameter Force { get; set; }
-
-        // If user specifies Force, disregard earlier authentication
-        protected override void BeginProcessing()
+        if (Force.IsPresent)
         {
-            base.BeginProcessing();
+            TokenManager.ClearCredential();
+        }
+    }
 
-            if (Force.IsPresent)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD104:Offer async methods", Justification = "PowerShell doesn't handle async.")]
+    protected override void EndProcessing()
+    {
+        if (TokenCache != null)
+        {
+            if (TokenCache == "msal.cache")
             {
-                TokenManager.ClearCredential();
+                WriteWarning("The name 'msal.cache' is the default cache name in MSAL, changing or clearing this cache might break other tools using it!");
             }
+            WriteWarning($"Number of accounts in cache: {CacheManager.GetAccounts(TokenCache).Length}");
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD104:Offer async methods", Justification = "PowerShell doesn't handle async.")]
-        protected override void EndProcessing()
-        {
-            WriteVerbose($"Getting token for {Resource} with scopes: {string.Join(", ", Scope)}.");
+        WriteVerbose($"Getting token for {Resource} with scopes: {string.Join(", ", Scope)}.");
 
-            if (ParameterSetName == "NonInteractive")
-            {
-                WriteVerbose(@"Looking for a token from the following sources:
+        if (ParameterSetName == "NonInteractive")
+        {
+            WriteVerbose(@"Looking for a token from the following sources:
 Environment variables (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential)
 Azure PowerShell (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential)
 Azure CLI (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential)
@@ -103,49 +113,53 @@ Visual Studio Code (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.
 Visual Studio (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential)
 Shared token cache (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential)
 ");
-                WriteObject(TokenManager.GetTokenNonInteractive(Resource, Scope, Claim, TenantId, stopProcessing.Token));
-            }
-            else if (ParameterSetName == "Cache")
-            {
-                WriteVerbose($"Getting token from token cache named \"{TokenCache}\" (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential).");
-                WriteObject(TokenManager.GetTokenFromCache(Resource, Scope, Claim, TenantId, TokenCache, Username, stopProcessing.Token));
-            }
-            else if (Interactive.IsPresent)
-            {
-                WriteVerbose("Getting token interactively using the default browser (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential).");
-                WriteObject(TokenManager.GetTokenInteractive(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, stopProcessing.Token));
-            }
-            else if (DeviceCode.IsPresent)
-            {
-                WriteVerbose("Getting token using device code flow (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.devicecodecredential).");
-                
-                // Set up a BlockingCollection to use for logging device code message
-                BlockingCollection<string> loggingQueue = new();
-                // Start device code flow and save task
-                var tokenTask = joinableTaskFactory.RunAsync(() => TokenManager.GetTokenDeviceCodeAsync(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, loggingQueue, stopProcessing.Token));
+            WriteObject(TokenManager.GetTokenNonInteractive(Resource, Scope, Claim, TenantId, stopProcessing.Token));
+        }
+        else if (ParameterSetName == "Cache")
+        {
+            WriteVerbose($"Getting token from token cache named \"{TokenCache}\" (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential).");
+            WriteObject(TokenManager.GetTokenFromCache(Resource, Scope, Claim, ClientId, TenantId, TokenCache!, Username, stopProcessing.Token));
+        }
+        else if (Interactive.IsPresent)
+        {
+            WriteVerbose("Getting token interactively using the default browser (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential).");
+            WriteObject(TokenManager.GetTokenInteractive(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, stopProcessing.Token));
+        }
+        else if (DeviceCode.IsPresent)
+        {
+            WriteVerbose("Getting token using device code flow (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.devicecodecredential).");
+            
+            // Set up a BlockingCollection to use for logging device code message
+            BlockingCollection<string> loggingQueue = new();
+            // Start device code flow and save task
+            var tokenTask = joinableTaskFactory.RunAsync(() => TokenManager.GetTokenDeviceCodeAsync(Resource, Scope, Claim, ClientId, TenantId, TokenCache, TimeoutSeconds, loggingQueue, stopProcessing.Token));
 
-                // Loop through messages and log them to warning stream (verbose is silent by default)
-                try
+            // Loop through messages and log them to warning stream (verbose is silent by default)
+            try
+            {
+                while (loggingQueue.TryTake(out string? message, Timeout.Infinite, stopProcessing.Token))
                 {
-                    while (loggingQueue.TryTake(out string? message, Timeout.Infinite, stopProcessing.Token))
-                    {
-                        WriteWarning(message);
-                    }
+                    WriteWarning(message);
                 }
-                catch (OperationCanceledException) { /* It's fine if user cancels */ }
+            }
+            catch (OperationCanceledException) { /* It's fine if user cancels */ }
 
-                // The device code message has been presented, now await task and output token when done
-                WriteObject(tokenTask.Join(stopProcessing.Token));
-            }
-            else if (ManagedIdentity.IsPresent)
-            {
-                WriteVerbose("Getting token as managed identity (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential).");
-                WriteObject(TokenManager.GetTokenManagedIdentity(Resource, Scope, Claim, ClientId, TenantId, stopProcessing.Token));
-            }
-            else
-            {
-                throw new ArgumentException("Invalid parameter combination!");
-            }
+            // The device code message has been presented, now await task and output token when done
+            WriteObject(tokenTask.Join(stopProcessing.Token));
+        }
+        else if (ManagedIdentity.IsPresent)
+        {
+            WriteVerbose("Getting token as managed identity (https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential).");
+            WriteObject(TokenManager.GetTokenManagedIdentity(Resource, Scope, Claim, ClientId, TenantId, stopProcessing.Token));
+        }
+        else
+        {
+            throw new ArgumentException("Invalid parameter combination!");
+        }
+
+        if (TokenCache != null)
+        {
+            WriteWarning($"Number of accounts in cache: {CacheManager.GetAccounts(TokenCache).Length}");
         }
     }
 }

--- a/Source/AzAuth.PS/Manifest/AzAuth.psd1
+++ b/Source/AzAuth.PS/Manifest/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.2.1'
+ModuleVersion = '2.2.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -64,7 +64,10 @@ PowerShellVersion = '7.2'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = 'Get-AzToken'
+CmdletsToExport = @(
+    'Get-AzToken'
+    'Clear-AzTokenCache'
+)
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/Tests/Clear-AzTokenCache.Tests.ps1
+++ b/Tests/Clear-AzTokenCache.Tests.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter()]
+    [ValidateScript({ $_ -match '\.psd1$' }, ErrorMessage = 'Please input a .psd1 file')]
+    $Manifest
+)
+
+BeforeDiscovery {
+    . "$PSScriptRoot\CommonTestLogic.ps1"
+    Invoke-ModuleReload -Manifest $Manifest
+    
+    $ParameterTestCases += @(
+        @{
+            Name          = 'TokenCache'
+            Type          = 'string'
+        }
+    )
+}
+
+Describe 'Get-AzToken' {
+    BeforeAll {        
+        # Get command from current test file name
+        $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')
+    }
+
+    Context 'parameters' {
+        It 'only has expected parameters' -TestCases @{ Parameters = $ParameterTestCases.Name } {
+            $Command.Parameters.GetEnumerator() | Where-Object {
+                $_.Key -notin [System.Management.Automation.Cmdlet]::CommonParameters -and
+                $_.Key -notin $Parameters
+            } | Should -BeNullOrEmpty
+        }
+
+        It 'has parameter <Name> of type <Type>' -TestCases $ParameterTestCases {
+            $Command | Should -HaveParameter $Name -Type $Type
+        }
+    }
+}

--- a/Tests/Clear-AzTokenCache.Tests.ps1
+++ b/Tests/Clear-AzTokenCache.Tests.ps1
@@ -16,7 +16,7 @@ BeforeDiscovery {
     )
 }
 
-Describe 'Get-AzToken' {
+Describe 'Clear-AzTokenCache' {
     BeforeAll {        
         # Get command from current test file name
         $Command = Get-Command ((Split-Path $PSCommandPath -Leaf) -replace '.Tests.ps1')

--- a/Tests/Get-AzToken.Tests.ps1
+++ b/Tests/Get-AzToken.Tests.ps1
@@ -60,6 +60,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $false }
             )
         }
         @{
@@ -75,7 +76,7 @@ BeforeDiscovery {
             Name          = 'Username'
             Type          = 'string'
             ParameterSets = @(
-                @{ Name = 'Cache'; Mandatory = $false }
+                @{ Name = 'Cache'; Mandatory = $true }
             )
         }
         @{


### PR DESCRIPTION
- Cache now works for personal accounts, closes #22 
- Argument completion for username by cache
- Username now mandatory when getting from cache
- New command `Clear-AzTokenCache`
- Version bump 2.2.2