### PR TITLE
Support for workload identity / federated credentials

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "Source\\AzAuth.sln"
+}

--- a/Docs/Help/Clear-AzTokenCache.md
+++ b/Docs/Help/Clear-AzTokenCache.md
@@ -14,7 +14,7 @@ Clear all tokens from a specified token cache.
 ## SYNTAX
 
 ```
-Clear-AzTokenCache -TokenCache <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Clear-AzTokenCache -TokenCache <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/Docs/Help/Clear-AzTokenCache.md
+++ b/Docs/Help/Clear-AzTokenCache.md
@@ -49,23 +49,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProgressAction
-{{ Fill ProgressAction Description }}
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Docs/Help/Clear-AzTokenCache.md
+++ b/Docs/Help/Clear-AzTokenCache.md
@@ -14,7 +14,7 @@ Clear all tokens from a specified token cache.
 ## SYNTAX
 
 ```
-Clear-AzTokenCache -TokenCache <String> [<CommonParameters>]
+Clear-AzTokenCache -TokenCache <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,6 +43,21 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Docs/Help/Get-AzToken.md
+++ b/Docs/Help/Get-AzToken.md
@@ -15,42 +15,40 @@ Gets a new Azure access token.
 
 ### NonInteractive (Default)
 ```
-Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>] [-Force]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
+ [-Force] [<CommonParameters>]
 ```
 
 ### Cache
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] -TokenCache <String> -Username <String> [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+ [-ClientId <String>] -TokenCache <String> -Username <String> [<CommonParameters>]
 ```
 
 ### Interactive
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
  [-ClientId <String>] [-TokenCache <String>] [-TimeoutSeconds <Int32>] [-Interactive] [-Force]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### DeviceCode
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
  [-ClientId <String>] [-TokenCache <String>] [-TimeoutSeconds <Int32>] [-DeviceCode] [-Force]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### ManagedIdentity
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-ManagedIdentity] [-Force] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-ClientId <String>] [-ManagedIdentity] [-Force] [<CommonParameters>]
 ```
 
 ### WorkloadIdentity
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] -TenantId <String> [-Claim <String>]
- -ClientId <String> [-WorkloadIdentity] -ExternalToken <String> [-Force] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+ -ClientId <String> [-WorkloadIdentity] -ExternalToken <String> [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/Docs/Help/Get-AzToken.md
+++ b/Docs/Help/Get-AzToken.md
@@ -16,33 +16,41 @@ Gets a new Azure access token.
 ### NonInteractive (Default)
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>] [-Force]
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Cache
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] -TokenCache <String> -Username <String> [<CommonParameters>]
+ [-ClientId <String>] -TokenCache <String> -Username <String> [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ### Interactive
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
  [-ClientId <String>] [-TokenCache <String>] [-TimeoutSeconds <Int32>] [-Interactive] [-Force]
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### DeviceCode
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
  [-ClientId <String>] [-TokenCache <String>] [-TimeoutSeconds <Int32>] [-DeviceCode] [-Force]
- [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ManagedIdentity
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-ManagedIdentity] [-Force] [<CommonParameters>]
+ [-ClientId <String>] [-ManagedIdentity] [-Force] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### WorkloadIdentity
+```
+Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] -TenantId <String> [-Claim <String>]
+ -ClientId <String> [-WorkloadIdentity] -ExternalToken <String> [-Force] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -135,6 +143,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+```yaml
+Type: String
+Parameter Sets: WorkloadIdentity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DeviceCode
 
 Get a token using a device code login interactively, for example on a different device.
@@ -142,6 +162,22 @@ Get a token using a device code login interactively, for example on a different 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: DeviceCode
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExternalToken
+
+The external token used for the federated credential of the workload identity. Used for the client assertion flow.
+
+```yaml
+Type: String
+Parameter Sets: WorkloadIdentity
 Aliases:
 
 Required: True
@@ -159,7 +195,7 @@ This may be required when combining interactive and non-interactive authenticati
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: NonInteractive, Interactive, DeviceCode, ManagedIdentity
+Parameter Sets: NonInteractive, Interactive, DeviceCode, ManagedIdentity, WorkloadIdentity
 Aliases:
 
 Required: False
@@ -245,10 +281,22 @@ The id of the tenant that the token should be valid for.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: NonInteractive, Cache, Interactive, DeviceCode, ManagedIdentity
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: WorkloadIdentity
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -315,8 +363,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -WorkloadIdentity
+
+Get a token using a federated credential, or "workload identity federation".
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: WorkloadIdentity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Source/AzAuth.Core/AzAuth.Core.csproj
+++ b/Source/AzAuth.Core/AzAuth.Core.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="AzAuth.PS" />
-	  <PackageReference Include="Azure.Identity" Version="1.8.2" />
+	  <PackageReference Include="Azure.Identity" Version="1.10.4" />
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
+	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.8.14" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
 	  <PackageReference Include="System.Management.Automation" Version="7.2.11" />
 	  <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
   </ItemGroup>

--- a/Source/AzAuth.PS/AzAuth.PS.csproj
+++ b/Source/AzAuth.PS/AzAuth.PS.csproj
@@ -11,7 +11,7 @@
 	
   <ItemGroup>
     <ProjectReference Include="..\AzAuth.Core\AzAuth.Core.csproj" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.8.14" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="All" />
   </ItemGroup>
 	

--- a/Source/AzAuth.PS/Manifest/AzAuth.psd1
+++ b/Source/AzAuth.PS/Manifest/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.2.3'
+ModuleVersion = '2.2.4'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -90,7 +90,23 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'azure', 'token', 'oauth', 'identity', 'authentication', 'authorization', 'authn', 'authz'
+        Tags = @(
+            'azure',
+            'auth',
+            'token',
+            'oauth',
+            'identity',
+            'authentication',
+            'authorization',
+            'authn',
+            'authz',
+            'service principal',
+            'managed identity',
+            'workload identity',
+            'federation',
+            'credential'
+            'OIDC'
+        )
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/PalmEmanuel/AzAuth/blob/main/LICENSE'

--- a/Tests/Get-AzToken.Tests.ps1
+++ b/Tests/Get-AzToken.Tests.ps1
@@ -18,6 +18,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $false }
             )
         }
         @{
@@ -29,6 +30,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $false }
             )
         }
         @{
@@ -40,6 +42,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $true }
             )
         }
         @{
@@ -51,6 +54,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $false }
             )
         }
         @{
@@ -60,6 +64,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $true }
                 @{ Name = 'Cache'; Mandatory = $false }
             )
         }
@@ -109,6 +114,20 @@ BeforeDiscovery {
             )
         }
         @{
+            Name          = 'WorkloadIdentity'
+            Type          = 'System.Management.Automation.SwitchParameter'
+            ParameterSets = @(
+                @{ Name = 'WorkloadIdentity'; Mandatory = $true }
+            )
+        }
+        @{
+            Name          = 'ExternalToken'
+            Type          = 'string'
+            ParameterSets = @(
+                @{ Name = 'WorkloadIdentity'; Mandatory = $true }
+            )
+        }
+        @{
             Name          = 'Force'
             Type          = 'System.Management.Automation.SwitchParameter'
             ParameterSets = @(
@@ -116,6 +135,7 @@ BeforeDiscovery {
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }
+                @{ Name = 'WorkloadIdentity'; Mandatory = $false }
             )
         }
     )


### PR DESCRIPTION
## Description

- Version bump to 2.2.4
- Implemented #19 
  - `Get-AzToken -WorkloadIdentity -ExternalToken $OidcToken -ClientId $ClientId -TenantId $TenantId`
  - New parameter `-WorkloadIdentity`
  - New parameter `-ExternalToken` 
- Updated dependencies to fix

## Example use

Azure DevOps pipeline example (with the module in the repo):

```
steps:
- task: AzurePowerShell@5
  env:
    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
  inputs:
    azureSubscription: 'workload-identity-test'
    pwsh: true
    azurePowerShellVersion: 'LatestVersion'
    ScriptType : 'InlineScript'
    Inline: |
      $ClientId = '<client-id>'
      $TenantId = '<tenant-id>'

      Import-Module AzAuth

      # The service connection ID can be found stored in any of the environment variables named ENDPOINT_DATA_<ServiceConnectionId>_<Something>URL
      try {
          $ServiceConnectionId = (Get-ChildItem -Path Env: -Recurse -Include ENDPOINT_DATA_*)[0].Name.Split('_')[2]
      } catch {
          throw "Unable to determine service connection ID!"
      }
      
      $Uri = "${env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${env:SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build/plans/${env:SYSTEM_PLANID}/jobs/${env:SYSTEM_JOBID}/oidctoken?serviceConnectionId=${ServiceConnectionId}&api-version=7.1-preview.1"
    
      $InvokeSplat = @{
        'Uri' = $Uri
        'Method' = 'POST'
        'Headers' = @{
          'Authorization' = "Bearer $($env:SYSTEM_ACCESSTOKEN)"
        }
        'ContentType' = 'application/json'
      }
      $OidcToken = (Invoke-RestMethod @InvokeSplat).oidcToken

      Get-AzToken -WorkloadIdentity -ExternalToken $OidcToken -ClientId $ClientId -TenantId $TenantId
```