### PR TITLE
Added all claims to `Get-AzToken` output token type as `Claims` property

### DIFF
--- a/Source/AzAuth.Core/CacheManager.cs
+++ b/Source/AzAuth.Core/CacheManager.cs
@@ -74,10 +74,17 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        var resultClaims = new ClaimsDictionary();
+        foreach (var claim in result.ClaimsPrincipal.Claims)
+        {
+            resultClaims.Add(claim.Type, claim.Value);
+        }
+
         return new AzToken(
             result.AccessToken,
             result.Scopes.ToArray(),
             result.ExpiresOn,
+            resultClaims,
             result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
             result.TenantId
         );
@@ -117,10 +124,17 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        var resultClaims = new ClaimsDictionary();
+        foreach (var claim in result.ClaimsPrincipal.Claims)
+        {
+            resultClaims.Add(claim.Type, claim.Value);
+        }
+
         return new AzToken(
             result.AccessToken,
             result.Scopes.ToArray(),
             result.ExpiresOn,
+            resultClaims,
             result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
             result.TenantId
         );
@@ -152,10 +166,17 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        var resultClaims = new ClaimsDictionary();
+        foreach (var claim in result.ClaimsPrincipal.Claims)
+        {
+            resultClaims.Add(claim.Type, claim.Value);
+        }
+
         return new AzToken(
             result.AccessToken,
             result.Scopes.ToArray(),
             result.ExpiresOn,
+            resultClaims,
             result.Account.Username ?? result.Account.HomeAccountId.ObjectId,
             result.TenantId
         );

--- a/Source/AzAuth.Core/Models/AzToken.cs
+++ b/Source/AzAuth.Core/Models/AzToken.cs
@@ -7,18 +7,17 @@ public class AzToken
     public string? Identity { get; }
     public string? TenantId { get; }
     public string[] Scopes { get; }
+    public ClaimsDictionary Claims { get; }
 
-    public AzToken(string token, string[] scopes, DateTimeOffset expiresOn, string? identity = null, string? tenantId = null)
+    public AzToken(string token, string[] scopes, DateTimeOffset expiresOn, ClaimsDictionary claims, string? identity = null, string? tenantId = null)
     {
         Token = token;
         Identity = identity;
         TenantId = tenantId;
         Scopes = scopes;
         ExpiresOn = expiresOn;
+        Claims = claims;
     }
 
-    public override string ToString()
-    {
-        return Token;
-    }
+    public override string ToString() => Token;
 }

--- a/Source/AzAuth.Core/Models/ClaimList.cs
+++ b/Source/AzAuth.Core/Models/ClaimList.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+
+namespace PipeHow.AzAuth;
+
+public class ClaimList : IReadOnlyList<string>
+{
+    private List<string> _list;
+
+    public ClaimList() => _list = new List<string>();
+
+    public string this[int index] => _list[index];
+
+    public int Count => _list.Count;
+
+    public IEnumerator<string> GetEnumerator() => _list.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+
+    public void Add(string claim)
+    {
+        _list.Add(claim);
+    }
+
+    public override string ToString()
+    {
+        return string.Join(", ", _list);
+    }
+}

--- a/Source/AzAuth.Core/Models/ClaimsDictionary.cs
+++ b/Source/AzAuth.Core/Models/ClaimsDictionary.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+
+namespace PipeHow.AzAuth;
+
+// Custom dictionary to index claims which are key value pairs with one or more strings as values
+public class ClaimsDictionary : IReadOnlyDictionary<string, ClaimList?>
+{
+    private readonly Dictionary<string, ClaimList> _dictionary;
+
+    public ClaimsDictionary() => _dictionary = new Dictionary<string, ClaimList>();
+
+    public ClaimList? this[string key] => _dictionary.ContainsKey(key) ? _dictionary[key] : null;
+
+    public IEnumerable<string> Keys => _dictionary.Keys;
+
+    public IEnumerable<ClaimList> Values => _dictionary.Values;
+
+    public int Count => _dictionary.Count;
+
+    public bool ContainsKey(string key) => _dictionary.ContainsKey(key);
+
+    public bool TryGetValue(string key, out ClaimList value) => _dictionary.TryGetValue(key, out value);
+
+    public IEnumerator<KeyValuePair<string, ClaimList?>> GetEnumerator() => _dictionary.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+
+    public void Add(string key, string value)
+    {
+        if (_dictionary.ContainsKey(key))
+        {
+            _dictionary[key].Add(value);
+        }
+        else
+        {
+            _dictionary[key] = new ClaimList { value };
+        }
+    }
+
+    public override string ToString()
+    {
+        return string.Join(", ", _dictionary.Select(kvp => $"[{kvp.Key}: {string.Join(", ", kvp.Value ?? Enumerable.Empty<string>())}]"));
+    }
+}

--- a/Source/AzAuth.Core/TokenManager.cs
+++ b/Source/AzAuth.Core/TokenManager.cs
@@ -25,6 +25,7 @@ internal static partial class TokenManager
         // Parse token to get info from claims
         var handler = new JwtSecurityTokenHandler();
         var jsonToken = handler.ReadJwtToken(token.Token);
+
         // Get upn of user if available, or email if personal account, otherwise object id of identity used (such as managed identity)
         var identity = (jsonToken.Claims.FirstOrDefault(c => c.Type == "upn") ??
             jsonToken.Claims.FirstOrDefault(c => c.Type == "email") ??
@@ -32,10 +33,17 @@ internal static partial class TokenManager
         var tenantId = jsonToken.Claims.FirstOrDefault(c => c.Type == "tid");
         var scopes = jsonToken.Claims.FirstOrDefault(c => c.Type == "scp");
 
+        var claims = new ClaimsDictionary();
+        foreach (var claim in jsonToken.Claims)
+        {
+            claims.Add(claim.Type, claim.Value);
+        }
+
         return new AzToken(
             token.Token,
             scopes?.Value.Split(' ') ?? tokenRequestContext.Scopes,
             token.ExpiresOn,
+            claims,
             identity,
             tenantId?.Value ?? tokenRequestContext.TenantId
         );

--- a/Source/AzAuth.PS/Manifest/AzAuth.psd1
+++ b/Source/AzAuth.PS/Manifest/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.2.6'
+ModuleVersion = '2.2.7'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'


### PR DESCRIPTION
New `Claims` property for the token output.

Implemented custom `ClaimsDictionary` with custom `ClaimList` to hold one or more values (strings) for each claim key (string). The need for custom types was to override `ToString()` so that it the nested property / value strings would be possible to present when the user gets the token in the PowerShell console.

- Closes #34 