### PR TITLE
`-TimeoutSeconds` for Managed Identity, Managed Identity auth as first option in noninteractive auth

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -27,11 +27,21 @@ runs:
     shell: pwsh
     run: ./build.ps1 -ResolveDependency -Task noop
 
+  # Replace dot in semVer with dash, for Sampler validation in pre-release
+  - name: Format semVer for Sampler
+    id: formatSemVer
+    shell: pwsh
+    run: |
+      $SemVer = '${{ steps.gitversion.outputs.semVer }}'
+      # Replace last dot with dash for Sampler to accept it as pre-release, does not allow dots in pre-release name
+      $SemVer = $SemVer -replace '^([\d\.]+\-\w+)\.(\d+)$','$1-$2'
+      Add-Content -Path $env:GITHUB_OUTPUT -Value "formattedSemVer=$SemVer"
+
   - name: Build module
     shell: pwsh
     run: ./build.ps1 -tasks pack
     env:
-      ModuleVersion: ${{ env.gitVersion.NuGetVersionV2 }}
+      ModuleVersion: ${{ steps.formatSemVer.outputs.formattedSemVer }}
 
   - name: Publish build artifacts
     uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on and uses the types of changes according to [Keep a Change
 ### Added
 
 - Adds related links links to blog posts for Get-AzToken and the parameters -WorkloadIdentity & -ExternalToken
+- Added `-TimeoutSeconds` parameter for Managed Identity authentication and non-interactive authentication
+- Added Managed Identity authentication as first option of non-interactive login
 
 ## [2.2.10] - 2024-05-22
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -11,18 +11,22 @@ branches:
     label: preview
     regex: ^main$
     increment: Patch
+    is-main-branch: true
   pull-request:
     label: PR
+    is-main-branch: false
   feature:
     label: useBranchName
     increment: Minor
     regex: f(eature(s)?)?[\/-]
     source-branches: ['main']
+    is-main-branch: false
   hotfix:
     label: fix
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
     source-branches: ['main']
+    is-main-branch: false
 
 ignore:
   sha: []

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,33 +1,116 @@
-strategies:
-  - Mainline
-next-version: 0.0.1
-major-version-bump-message: '(breaking\schange|breaking|major)\b'
-minor-version-bump-message: '(adds?|features?|minor)\b'
-patch-version-bump-message: '\s?(fix|patch)'
+assembly-versioning-scheme: MajorMinorPatch
+assembly-file-versioning-scheme: MajorMinorPatch
+tag-prefix: '[vV]?'
+version-in-branch-pattern: (?<version>[vV]?\d+(\.\d+)?(\.\d+)?).*
+major-version-bump-message: '\+semver:\s?(breaking|major)'
+minor-version-bump-message: '\+semver:\s?(feature|minor)'
+patch-version-bump-message: '\+semver:\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
-assembly-informational-format: 'MajorMinorPatch'
+tag-pre-release-weight: 60000
+commit-date-format: yyyy-MM-dd
+merge-message-formats: {}
+update-build-number: true
+semantic-version-format: Strict
+strategies:
+- Fallback
+- ConfiguredNextVersion
+- MergeMessage
+- TaggedCommit
+- TrackReleaseBranches
+- VersionInBranchName
 branches:
   main:
-    label: preview
-    regex: ^main$
+    label: 'preview'
     increment: Patch
+    prevent-increment:
+      of-merged-branch: true
+    track-merge-target: false
+    track-merge-message: true
+    regex: ^master$|^main$
+    source-branches: []
+    is-source-branch-for: []
+    tracks-release-branches: false
+    is-release-branch: false
     is-main-branch: true
-  pull-request:
-    label: PR
-    is-main-branch: false
-  feature:
-    label: useBranchName
-    increment: Minor
-    regex: f(eature(s)?)?[\/-]
-    source-branches: ['main']
-    is-main-branch: false
-  hotfix:
-    label: fix
+    pre-release-weight: 55000
+  release:
+    mode: ManualDeployment
+    label: beta
     increment: Patch
-    regex: (hot)?fix(es)?[\/-]
-    source-branches: ['main']
+    prevent-increment:
+      of-merged-branch: true
+      when-branch-merged: false
+      when-current-commit-tagged: false
+    track-merge-target: false
+    track-merge-message: true
+    regex: ^releases?[/-](?<BranchName>.+)
+    source-branches:
+    - main
+    is-source-branch-for: []
+    tracks-release-branches: false
+    is-release-branch: true
     is-main-branch: false
-
+    pre-release-weight: 30000
+  feature:
+    mode: ManualDeployment
+    label: '{BranchName}'
+    increment: Inherit
+    prevent-increment:
+      when-current-commit-tagged: false
+    track-merge-message: true
+    regex: ^features?[/-](?<BranchName>.+)
+    source-branches:
+    - main
+    - release
+    is-source-branch-for: []
+    is-main-branch: false
+    pre-release-weight: 30000
+  pull-request:
+    mode: ContinuousDelivery
+    label: PullRequest
+    increment: Inherit
+    prevent-increment:
+      of-merged-branch: true
+      when-current-commit-tagged: false
+    label-number-pattern: '[/-](?<number>\d+)'
+    track-merge-message: true
+    regex: ^(pull|pull\-requests|pr)[/-]
+    source-branches:
+    - main
+    - release
+    - feature
+    is-source-branch-for: []
+    pre-release-weight: 30000
+  unknown:
+    mode: ManualDeployment
+    label: '{BranchName}'
+    increment: Inherit
+    prevent-increment:
+      when-current-commit-tagged: false
+    track-merge-message: false
+    regex: (?<BranchName>.+)
+    source-branches:
+    - main
+    - release
+    - feature
+    - pull-request
+    is-source-branch-for: []
+    is-main-branch: false
 ignore:
   sha: []
-merge-message-formats: {}
+mode: ContinuousDelivery
+label: '{BranchName}'
+increment: Inherit
+prevent-increment:
+  of-merged-branch: false
+  when-branch-merged: false
+  when-current-commit-tagged: true
+track-merge-target: false
+track-merge-message: true
+commit-message-incrementing: Enabled
+regex: ''
+source-branches: []
+is-source-branch-for: []
+tracks-release-branches: false
+is-release-branch: false
+is-main-branch: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,40 +1,29 @@
-mode: ContinuousDelivery
+strategies:
+  - Mainline
 next-version: 0.0.1
 major-version-bump-message: '(breaking\schange|breaking|major)\b'
 minor-version-bump-message: '(adds?|features?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
-assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
+assembly-informational-format: 'MajorMinorPatch'
 branches:
-  master:
-    tag: preview
+  main:
+    label: preview
     regex: ^main$
+    increment: Patch
   pull-request:
-    tag: PR
+    label: PR
   feature:
-    tag: useBranchName
+    label: useBranchName
     increment: Minor
     regex: f(eature(s)?)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
   hotfix:
-    tag: fix
+    label: fix
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
-    source-branches: ['master']
+    source-branches: ['main']
 
 ignore:
   sha: []
 merge-message-formats: {}
-
-
-# feature:
-#   tag: useBranchName
-#   increment: Minor
-#   regex: f(eature(s)?)?[/-]
-#   source-branches: ['master']
-# hotfix:
-#   tag: fix
-#   increment: Patch
-#   regex: (hot)?fix(es)?[/-]
-#   source-branches: ['master']
-

--- a/docs/help/Get-AzToken.md
+++ b/docs/help/Get-AzToken.md
@@ -15,8 +15,8 @@ Gets a new Azure access token.
 
 ### NonInteractive (Default)
 ```
-Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>] [-Force]
- [<CommonParameters>]
+Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
+ [-TimeoutSeconds <Int32>] [-Force] [<CommonParameters>]
 ```
 
 ### Cache
@@ -43,7 +43,8 @@ Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-
 ### ManagedIdentity
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-ManagedIdentity] [-Force] [<CommonParameters>]
+ [-ClientId <String>] [-TimeoutSeconds <Int32>] [-ManagedIdentity] [-Force]
+ [<CommonParameters>]
 ```
 
 ### WorkloadIdentity
@@ -409,7 +410,7 @@ The number of seconds to wait until the login times out.
 
 ```yaml
 Type: Int32
-Parameter Sets: Interactive, DeviceCode
+Parameter Sets: NonInteractive, Interactive, DeviceCode, ManagedIdentity
 Aliases:
 
 Required: False

--- a/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
+++ b/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
@@ -1,5 +1,8 @@
 ﻿using Azure.Core;
+using Azure.Core.Diagnostics;
+using Azure.Core.Pipeline;
 using Azure.Identity;
+using System.Diagnostics.Tracing;
 using System.Text.RegularExpressions;
 
 namespace PipeHow.AzAuth;
@@ -9,8 +12,8 @@ internal static partial class TokenManager
     /// <summary>
     /// Gets token noninteractively.
     /// </summary>
-    internal static AzToken GetTokenNonInteractive(string resource, string[] scopes, string? claims, string? tenantId, CancellationToken cancellationToken) =>
-        taskFactory.Run(() => GetTokenNonInteractiveAsync(resource, scopes, claims, tenantId, cancellationToken));
+    internal static AzToken GetTokenNonInteractive(string resource, string[] scopes, string? claims, string? tenantId, int? timeoutSeconds, int managedIdentityTimeoutSeconds, CancellationToken cancellationToken) =>
+        taskFactory.Run(() => GetTokenNonInteractiveAsync(resource, scopes, claims, tenantId, timeoutSeconds, managedIdentityTimeoutSeconds, cancellationToken));
 
     /// <summary>
     /// Gets token noninteractively.
@@ -20,19 +23,42 @@ internal static partial class TokenManager
         string[] scopes,
         string? claims,
         string? tenantId,
+        int? timeoutSeconds,
+        int managedIdentityTimeoutSeconds,
         CancellationToken cancellationToken)
     {
         var fullScopes = scopes.Select(s => $"{resource.TrimEnd('/')}/{s}").ToArray();
 
+        // If timeoutSeconds is not null, create a new TokenCredentialOptions with the specified timeout
+        // Otherwise, set to null to use default timeout
+        TokenCredentialOptions? genericTimeoutOptions = timeoutSeconds.HasValue ? new TokenCredentialOptions
+        {
+            Retry = {
+                NetworkTimeout = TimeSpan.FromSeconds(timeoutSeconds.Value),
+                MaxRetries = 0,
+                Delay = TimeSpan.Zero,
+                MaxDelay = TimeSpan.Zero
+            }
+        } : null;
+
         // Create our own credential chain because we want to change the order
         var sources = new List<TokenCredential>()
         {
-            new EnvironmentCredential(),
-            new AzurePowerShellCredential(),
-            new AzureCliCredential(),
-            new VisualStudioCodeCredential(),
-            new VisualStudioCredential(),
-            new SharedTokenCacheCredential()
+            // ManagedIdentityCredential with custom timeout
+            new ManagedIdentityCredential(options: new TokenCredentialOptions{
+                Retry = {
+                    NetworkTimeout = TimeSpan.FromSeconds(managedIdentityTimeoutSeconds),
+                    MaxRetries = 0,
+                    Delay = TimeSpan.Zero,
+                    MaxDelay = TimeSpan.Zero
+                }
+            }),
+            new EnvironmentCredential(genericTimeoutOptions),
+            new AzurePowerShellCredential(genericTimeoutOptions as AzurePowerShellCredentialOptions),
+            new AzureCliCredential(genericTimeoutOptions as AzureCliCredentialOptions),
+            new VisualStudioCodeCredential(genericTimeoutOptions as VisualStudioCodeCredentialOptions),
+            new VisualStudioCredential(genericTimeoutOptions as VisualStudioCredentialOptions),
+            new SharedTokenCacheCredential(genericTimeoutOptions as SharedTokenCacheCredentialOptions)
         };
 
         // If user authenticated interactively in the same session and tenant didn't change, add it as the first option to find tokens from

--- a/tests/Get-AzToken.Tests.ps1
+++ b/tests/Get-AzToken.Tests.ps1
@@ -94,7 +94,9 @@ BeforeDiscovery {
             Name          = 'TimeoutSeconds'
             Type          = 'int'
             ParameterSets = @(
+                @{ Name = 'NonInteractive'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
+                @{ Name = 'ManagedIdentity'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
             )
         }


### PR DESCRIPTION
# Pull Request

Closes:
- #85 
- #84 

## Pull Request (PR) description

### Added

- Added `-TimeoutSeconds` parameter for Managed Identity authentication and non-interactive authentication
- Added Managed Identity authentication as first option of non-interactive login

## Task list

<!--
    To aid reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.
