### PR TITLE
Clarifies use of clientid with non-interactive auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Changed
+
+- Parameter -ClientId now explains usage in a warning message when used with non-interactive parameter set
+
 ## [2.3.0] - 2024-08-21
 
 ### Fixed

--- a/docs/help/Get-AzToken.md
+++ b/docs/help/Get-AzToken.md
@@ -16,7 +16,8 @@ Gets a new Azure access token.
 ### NonInteractive (Default)
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-TimeoutSeconds <Int32>] [-Force] [<CommonParameters>]
+ [-ClientId <String>] [-TimeoutSeconds <Int32>] [-Force]
+ [<CommonParameters>]
 ```
 
 ### Cache
@@ -218,7 +219,7 @@ The client id of the application used to authenticate the user or identity. If n
 
 ```yaml
 Type: String
-Parameter Sets: Cache, Interactive, DeviceCode, ManagedIdentity
+Parameter Sets: NonInteractive, Cache, Interactive, DeviceCode, ManagedIdentity
 Aliases:
 
 Required: False

--- a/source/AzAuth.Core/TokenManager.cs
+++ b/source/AzAuth.Core/TokenManager.cs
@@ -53,4 +53,9 @@ internal static partial class TokenManager
     {
         credential = null;
     }
+
+    internal static bool HasClientId()
+    {
+        return !string.IsNullOrEmpty(previousClientId);
+    }
 }

--- a/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.Interactive.cs
+++ b/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.Interactive.cs
@@ -39,7 +39,9 @@ internal static partial class TokenManager
 
         // Create a new credential
         credential = new InteractiveBrowserCredential(options);
-
+        
+        previousClientId = clientId;
+        
         try
         {
             // Create a new cancellation token by combining a timeout with existing token

--- a/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
+++ b/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
@@ -1,8 +1,5 @@
 ﻿using Azure.Core;
-using Azure.Core.Diagnostics;
-using Azure.Core.Pipeline;
 using Azure.Identity;
-using System.Diagnostics.Tracing;
 using System.Text.RegularExpressions;
 
 namespace PipeHow.AzAuth;

--- a/source/AzAuth.PS/Cmdlets/GetAzToken.cs
+++ b/source/AzAuth.PS/Cmdlets/GetAzToken.cs
@@ -57,6 +57,7 @@ public class GetAzToken : PSLoggerCmdletBase
     [ValidateNotNullOrEmpty]
     public string Claim { get; set; }
 
+    [Parameter(ParameterSetName = "NonInteractive")]
     [Parameter(ParameterSetName = "Interactive")]
     [Parameter(ParameterSetName = "DeviceCode")]
     [Parameter(ParameterSetName = "ManagedIdentity")]
@@ -148,6 +149,20 @@ public class GetAzToken : PSLoggerCmdletBase
 
         if (ParameterSetName == "NonInteractive")
         {
+            if (MyInvocation.BoundParameters.ContainsKey("ClientId"))
+            {
+                if (TokenManager.HasClientId())
+                {
+                    WriteWarning(@"The ClientId is saved in the session from the previous interactive authentication. If you wish to use the same authentication, omit the ClientId parameter and any parameters indicating interactive authentication. For example:
+'Get-AzToken -Interactive -ClientId $ClientId -Resource $Resource -Scope $Scope'
+
+should be
+
+'Get-AzToken -Resource $Resource -Scope $Scope'");
+                }
+                throw new ArgumentException("The ClientId parameter is not supported for this parameter combination.");
+            }
+
             // If user didn't specify a timeout, default to 1 second for managed identity
             int managedIdentityTimeoutSeconds = 1;
             int? noninteractiveTimeoutSeconds = null;

--- a/tests/Get-AzToken.Tests.ps1
+++ b/tests/Get-AzToken.Tests.ps1
@@ -64,6 +64,7 @@ BeforeDiscovery {
             Name          = 'ClientId'
             Type          = 'string'
             ParameterSets = @(
+                @{ Name = 'NonInteractive'; Mandatory = $false }
                 @{ Name = 'Interactive'; Mandatory = $false }
                 @{ Name = 'DeviceCode'; Mandatory = $false }
                 @{ Name = 'ManagedIdentity'; Mandatory = $false }


### PR DESCRIPTION
# Pull Request

Closes #93 

## Pull Request (PR) description

### Changed
- Parameter `-ClientId` now explains usage in a warning message when used with non-interactive parameter set

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.
