### PR TITLE
Added `-CredentialPrecedence` parameter to NonInteractive authentication

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,7 +7,7 @@ runs:
   - name: Install GitVersion
     uses: gittools/actions/gitversion/setup@v3.0.0
     with:
-      versionSpec: '6.x'
+      versionSpec: '6.0.0'
 
   - name: Determine Version
     id: gitversion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Added
+
+- Added -CredentialPrecedence parameter to allow for setting the precedence of the credentials used for non-interactive authentication #13
+
 ### Changed
 
 - Parameter -ClientId now explains usage in a warning message when used with non-interactive parameter set
+
+### Fixed
+
+- Downgraded Azure.Identity until issue https://github.com/Azure/azure-sdk-for-net/issues/47057 is resolved #112
 
 ## [2.3.0] - 2024-08-21
 

--- a/docs/help/Get-AzToken.md
+++ b/docs/help/Get-AzToken.md
@@ -16,7 +16,7 @@ Gets a new Azure access token.
 ### NonInteractive (Default)
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-TimeoutSeconds <Int32>] [-Force]
+ [-ClientId <String>] [-TimeoutSeconds <Int32>] [-CredentialPrecedence <String[]>] [-Force]
  [<CommonParameters>]
 ```
 
@@ -37,8 +37,7 @@ Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-
 ### Broker
 ```
 Get-AzToken [[-Resource] <String>] [[-Scope] <String[]>] [-TenantId <String>] [-Claim <String>]
- [-ClientId <String>] [-TokenCache <String>] [-Broker]
- [<CommonParameters>]
+ [-ClientId <String>] [-Broker] [<CommonParameters>]
 ```
 
 ### DeviceCode
@@ -280,6 +279,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -CredentialPrecedence
+
+The order of precedence for the credentials to be used for getting a token non-interactively.
+
+```yaml
+Type: String[]
+Parameter Sets: NonInteractive
+Aliases:
+Accepted values: ManagedIdentity, Environment, AzurePowerShell, AzureCLI, VisualStudioCode, VisualStudio, SharedTokenCache
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DeviceCode
 
 Get a token using a device code login interactively, for example on a different device.
@@ -462,7 +478,7 @@ Accept wildcard characters: False
 
 ```yaml
 Type: String
-Parameter Sets: Interactive, Broker, DeviceCode
+Parameter Sets: Interactive, DeviceCode
 Aliases:
 
 Required: False

--- a/source/AzAuth.Core/AzAuth.Core.csproj
+++ b/source/AzAuth.Core/AzAuth.Core.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="AzAuth.PS" />
-	  <PackageReference Include="Azure.Identity" Version="1.13.1" />
-	  <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
+	  <PackageReference Include="Azure.Identity" Version="1.12.1" />
+	  <PackageReference Include="Azure.Identity.Broker" Version="1.1.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
 	  <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />

--- a/source/AzAuth.psd1
+++ b/source/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.2.9'
+ModuleVersion = '2.4.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -25,7 +25,7 @@ Copyright = '(c) Emanuel Palm. All rights reserved.'
 Description = 'A lightweight PowerShell module to handle Azure authentication, using the Azure.Identity MSAL library.'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '7.2'
+PowerShellVersion = '7.4'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/tests/Get-AzToken.Tests.ps1
+++ b/tests/Get-AzToken.Tests.ps1
@@ -114,6 +114,13 @@ BeforeDiscovery {
             )
         }
         @{
+            Name          = 'CredentialPrecedence'
+            Type          = 'string[]'
+            ParameterSets = @(
+                @{ Name = 'NonInteractive'; Mandatory = $false }
+            )
+        }
+        @{
             Name          = 'Interactive'
             Type          = 'System.Management.Automation.SwitchParameter'
             ParameterSets = @(


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE] Add support for X

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

### Added

- Added -CredentialPrecedence parameter to allow for setting the precedence of the credentials used for non-interactive authentication #13

### Fixed

- Downgraded Azure.Identity until issue https://github.com/Azure/azure-sdk-for-net/issues/47057 is resolved, tracked in this repo in #112

### Changed

- Bumped version to 2.4.0.

## Task list

<!--
    To aid reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or failed tests.
- [x] Markdown help added/updated.
- [x] Unit tests added/updated.
