### PR TITLE
Managed identity lower prio in NonInteractive, dependency bumps, claims fix

### DIFF
--- a/.build/tasks/AzAuth.Build.ps1
+++ b/.build/tasks/AzAuth.Build.ps1
@@ -5,7 +5,7 @@ param(
 
     [ValidateSet('Debug', 'Release')]
     [string]
-    $Configuration = 'Release'
+    $Configuration = (property CompileConfiguration 'Release')
 )
 
 task dotnetBuild {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "AzAuth",
+            "name": "Debug AzAuth",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
@@ -14,13 +14,16 @@
                 "-NoExit",
                 "-NoProfile",
                 "-Command",
-                "Import-Module ${workspaceFolder}/AzAuth/AzAuth.psd1",
+                "Import-Module ${workspaceFolder}/output/AzAuth -Verbose",
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "integratedTerminal",
-            "justMyCode": false,
-            "requireExactSource": false
+            "justMyCode": true,
+            "requireExactSource": false,
+            "env": {
+                "CompileConfiguration": "Debug",
+            }
         },
         {
           "name": "PowerShell: Binary Module Interactive Session",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,13 +7,13 @@
             "label": "build",
             "command": "${workspaceFolder}/build.ps1",
             "type": "shell",
-            "args": [
-                "Debug",
-            ],
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
+            "args": [
+                "build",
+            ],
             "presentation": {
                 "reveal": "always"
             },

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -67,14 +67,13 @@ branches:
     pre-release-weight: 30000
   pull-request:
     mode: ContinuousDelivery
-    label: PullRequest
+    label: PullRequest{Number}
     increment: Inherit
     prevent-increment:
       of-merged-branch: true
       when-current-commit-tagged: false
-    label-number-pattern: '[/-](?<number>\d+)'
     track-merge-message: true
-    regex: ^(pull|pull\-requests|pr)[/-]
+    regex: ^(pull-requests|pull|pr)[\/-](?<Number>\d*)
     source-branches:
     - main
     - release

--- a/docs/help/Get-AzToken.md
+++ b/docs/help/Get-AzToken.md
@@ -284,7 +284,7 @@ The order of precedence for the credentials to be used for getting a token non-i
 Type: String[]
 Parameter Sets: NonInteractive
 Aliases:
-Accepted values: ManagedIdentity, Environment, AzurePowerShell, AzureCLI, VisualStudioCode, VisualStudio, SharedTokenCache
+Accepted values: ManagedIdentity, Environment, AzurePowerShell, AzureCLI, VisualStudio, SharedTokenCache
 
 Required: False
 Position: Named

--- a/source/AzAuth.Core/AzAuth.Core.csproj
+++ b/source/AzAuth.Core/AzAuth.Core.csproj
@@ -11,13 +11,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="AzAuth.PS" />
-	  <PackageReference Include="Azure.Identity" Version="1.12.1" />
-	  <PackageReference Include="Azure.Identity.Broker" Version="1.1.0" />
-	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+	  <PackageReference Include="Azure.Identity" Version="1.14.1" />
+	  <PackageReference Include="Azure.Identity.Broker" Version="1.2.0" />
+	  <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
 	  <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
-	  <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.17.2" GeneratePathProperty="true"/>
+	  <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.19.3" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/AzAuth.Core/CacheManager.cs
+++ b/source/AzAuth.Core/CacheManager.cs
@@ -2,6 +2,7 @@
 using Microsoft.Identity.Client.Extensions.Msal;
 using Microsoft.VisualStudio.Threading;
 using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
 
 namespace PipeHow.AzAuth;
 
@@ -74,8 +75,11 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        // result.ClaimsPrincipal doesnt have the correct claims, so we extract claims from the token instead
         var resultClaims = new ClaimsDictionary();
-        foreach (var claim in result.ClaimsPrincipal.Claims)
+        var handler = new JwtSecurityTokenHandler();
+        var jsonToken = handler.ReadJwtToken(result.AccessToken);
+        foreach (var claim in jsonToken.Claims)
         {
             resultClaims.Add(claim.Type, claim.Value);
         }
@@ -124,8 +128,11 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        // result.ClaimsPrincipal doesnt have all the correct claims, so we extract claims from the token instead
         var resultClaims = new ClaimsDictionary();
-        foreach (var claim in result.ClaimsPrincipal.Claims)
+        var handler = new JwtSecurityTokenHandler();
+        var jsonToken = handler.ReadJwtToken(result.AccessToken);
+        foreach (var claim in jsonToken.Claims)
         {
             resultClaims.Add(claim.Type, claim.Value);
         }
@@ -166,8 +173,11 @@ internal static class CacheManager
 
         var result = await tokenBuilder.ExecuteAsync(cancellationToken);
 
+        // result.ClaimsPrincipal doesnt have all the correct claims, so we extract claims from the token instead
         var resultClaims = new ClaimsDictionary();
-        foreach (var claim in result.ClaimsPrincipal.Claims)
+        var handler = new JwtSecurityTokenHandler();
+        var jsonToken = handler.ReadJwtToken(result.AccessToken);
+        foreach (var claim in jsonToken.Claims)
         {
             resultClaims.Add(claim.Type, claim.Value);
         }

--- a/source/AzAuth.Core/TokenManager.cs
+++ b/source/AzAuth.Core/TokenManager.cs
@@ -21,7 +21,6 @@ internal static partial class TokenManager
             "Environment" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential",
             "AzurePowerShell" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential",
             "AzureCLI" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential",
-            "VisualStudioCode" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocodecredential",
             "VisualStudio" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential",
             "SharedTokenCache" => "https://learn.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential",
             _ => throw new ArgumentException("Invalid credential type", nameof(credentialType))

--- a/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.ManagedIdentity.cs
+++ b/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.ManagedIdentity.cs
@@ -29,7 +29,7 @@ internal static partial class TokenManager
         // Re-use the previous managed identity credential if client id didn't change
         if (credential is not ManagedIdentityCredential || previousClientId != clientId)
         {
-            credential = new ManagedIdentityCredential(clientId, options: new TokenCredentialOptions{
+            credential = new ManagedIdentityCredential(clientId, options: new ManagedIdentityCredentialOptions{
                 Retry = {
                     NetworkTimeout = TimeSpan.FromSeconds(timeoutSeconds),
                     MaxRetries = 0,

--- a/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
+++ b/source/AzAuth.Core/TokenManagerAuthMethods/TokenManager.NonInteractive.cs
@@ -46,7 +46,7 @@ internal static partial class TokenManager
         {
             sources.Add(credentialType switch
             {
-                "ManagedIdentity" => new ManagedIdentityCredential(options: new TokenCredentialOptions
+                "ManagedIdentity" => new ManagedIdentityCredential(options: new ManagedIdentityCredentialOptions
                 {
                     Retry = {
                         NetworkTimeout = TimeSpan.FromSeconds(managedIdentityTimeoutSeconds),
@@ -58,7 +58,6 @@ internal static partial class TokenManager
                 "Environment" => new EnvironmentCredential(genericTimeoutOptions),
                 "AzurePowerShell" => new AzurePowerShellCredential(genericTimeoutOptions as AzurePowerShellCredentialOptions),
                 "AzureCLI" => new AzureCliCredential(genericTimeoutOptions as AzureCliCredentialOptions),
-                "VisualStudioCode" => new VisualStudioCodeCredential(genericTimeoutOptions as VisualStudioCodeCredentialOptions),
                 "VisualStudio" => new VisualStudioCredential(genericTimeoutOptions as VisualStudioCredentialOptions),
                 "SharedTokenCache" => new SharedTokenCacheCredential(genericTimeoutOptions as SharedTokenCacheCredentialOptions),
                 _ => throw new ArgumentException("Invalid credential type", nameof(credentialType))

--- a/source/AzAuth.PS/AzAuth.PS.csproj
+++ b/source/AzAuth.PS/AzAuth.PS.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AzAuth.Core\AzAuth.Core.csproj" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" PrivateAssets="All" />
   </ItemGroup>
 	

--- a/source/AzAuth.PS/Cmdlets/GetAzToken.cs
+++ b/source/AzAuth.PS/Cmdlets/GetAzToken.cs
@@ -95,9 +95,10 @@ public class GetAzToken : PSLoggerCmdletBase
     public int TimeoutSeconds { get; set; } = 120;
 
     [Parameter(ParameterSetName = "NonInteractive")]
-    [ValidateSet("ManagedIdentity", "Environment", "AzurePowerShell", "AzureCLI", "VisualStudioCode", "VisualStudio", "SharedTokenCache")]
+    [ValidateSet("ManagedIdentity", "Environment", "AzurePowerShell", "AzureCLI", "VisualStudio", "SharedTokenCache")]
     [ValidateNotNullOrEmpty()]
-    public string[] CredentialPrecedence { get; set; } = ["ManagedIdentity", "Environment", "AzurePowerShell", "AzureCLI", "VisualStudioCode", "VisualStudio", "SharedTokenCache"];
+    // TODO: Change back ManagedIdentity to first position in the chain once issue #112 is solved, likely in Azure.Identity 1.14.2 or later
+    public string[] CredentialPrecedence { get; set; } = ["Environment", "AzurePowerShell", "AzureCLI", "VisualStudio", "SharedTokenCache", "ManagedIdentity"];
 
     [Parameter(ParameterSetName = "Interactive", Mandatory = true)]
     public SwitchParameter Interactive { get; set; }
@@ -178,7 +179,7 @@ should be
                 throw new ArgumentException("The ClientId parameter is not supported for this parameter combination.");
             }
 
-            // If user didn't specify a timeout, default to 1 second for managed identity
+            // If user didn't specify a timeout, set default for managed identity
             int managedIdentityTimeoutSeconds = 1;
             int? noninteractiveTimeoutSeconds = null;
             if (MyInvocation.BoundParameters.ContainsKey("TimeoutSeconds"))

--- a/source/AzAuth.psd1
+++ b/source/AzAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'AzAuth.PS.dll'
 
 # Version number of this module.
-ModuleVersion = '2.4.0'
+ModuleVersion = '2.5.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'


### PR DESCRIPTION
- Closes #137 
- Related to #112

### Removed

- Removed Visual Studio Code credential option which has been deprecated

### Changed

- When getting Tokens non-interactively, Managed Identity is now last in the credential chain until #112 is fixed
- Claims in token object now properly reflect the correct claims in the token #137 
- Bumped Azure.Identity from 1.12.1 to 1.14.1
- Bumped Microsoft.VisualStudio.Threading from 17.12.19 to 17.14.15
- Bumped Azure.Identity.Broker from 1.1.0 to 1.2.0
- Bumped System.IdentityModel.Tokens.Jwt from 8.3.0 to 8.12.1
- Bumped System.Security.Cryptography.ProtectedData from 9.0.0 to 9.0.6
- Bumped Microsoft.Identity.Client.NativeInterop from 0.17.2 to 0.19.3
