### PR TITLE
Adds integration tests for interactive, cache & client credentials flows

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -16,7 +16,7 @@ runs:
         path: ${{ env.buildFolderName }}
     
     - name: Run Tests
-      run: .\build.ps1 -tasks test
+      run: .\build.ps1 -tasks test -PesterExcludeTag 'Interactive'
       shell: pwsh
   
     - name: Publish Test Artifact

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -16,7 +16,7 @@ runs:
         path: ${{ env.buildFolderName }}
     
     - name: Run Tests
-      run: .\build.ps1 -tasks test -PesterExcludeTag 'Interactive'
+      run: .\build.ps1 -tasks test -PesterExcludeTag 'Integration'
       shell: pwsh
   
     - name: Publish Test Artifact

--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,9 @@ output/
 *.local.*
 **.bak
 markdownissues.txt
+
+# Ignore local test files
+test.ps1
+*.crt
+*.key
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on and uses the types of changes according to [Keep a Change
 
 ## [Unreleased]
 
+### Added
+
+- The name of the token cache being removed is now shown in the warning message when using `Clear-AzTokenCache` with the `-Force` parameter
+
 ## [2.6.0] - 2025-07-04
 
 ### Added

--- a/source/AzAuth.Core/CacheManager.cs
+++ b/source/AzAuth.Core/CacheManager.cs
@@ -323,18 +323,7 @@ internal static class CacheManager
         {
             throw new InvalidOperationException($"Directory '{cacheDir}' contains too many files ({fileCount}) to be a typical cache. Deletion aborted for safety.");
         }
-
-        try
-        {
-            // First try to clear the cache using MSAL to clean up properly
-            await ClearCacheAsync(cacheName, rootDir, cancellationToken);
-        }
-        catch
-        {
-            // If MSAL clearing fails, we'll still try to delete the files
-            // This could happen if the cache is corrupted or inaccessible
-        }
-
+        
         try
         {
             // Delete the entire cache directory and all its contents

--- a/source/AzAuth.PS/Cmdlets/ClearAzTokenCache.cs
+++ b/source/AzAuth.PS/Cmdlets/ClearAzTokenCache.cs
@@ -28,7 +28,7 @@ public class ClearAzTokenCache : PSLoggerCmdletBase
 
         if (Force)
         {
-            WriteWarning("Will attempt to delete all files for the token cache, this may cause issues with other applications using the same cache!");
+            WriteWarning($"Will attempt to delete all files for the token cache '{TokenCache}', this may cause issues with other applications using the same cache!");
             CacheManager.RemoveCache(TokenCache, RootPath, stopProcessing.Token);
         }
         else

--- a/tests/InteractiveIntegration.Tests.ps1
+++ b/tests/InteractiveIntegration.Tests.ps1
@@ -1,20 +1,20 @@
-BeforeDiscovery {
-    # These tests require user interaction and should only be run manually
-    Write-Host @'
-These tests require user interaction and will prompt for authentication.
-The tokens acquired in the integration tests are real, and should be handled as secrets!
-'@
-
-    . "$BuildRoot\tests\cases\TestCases.ps1"
-    $InteractiveTestCases = Get-TestCaseByType -CaseType 'InteractiveTests'
-}
-
 BeforeAll {
     $script:CachesToRemove = @()
 }
 
-Describe 'Get-AzToken interactive tests' -Tag 'Interactive' {
+Describe 'Get-AzToken interactive integration tests' -Tag 'Interactive', 'Integration' {
+    BeforeDiscovery {
+
+        . "$BuildRoot\tests\cases\TestCases.ps1"
+        $InteractiveTestCases = Get-TestCaseByType -CaseType 'InteractiveTests'
+    }
+    
     BeforeAll {
+        # These tests require user interaction and should only be run manually
+        Write-Host @'
+These tests require user interaction and will prompt for authentication.
+The tokens acquired in the integration tests are real, and should be handled as secrets!
+'@
         # Create a variable to hold the last username used
         # This allows us to save the username used in interactive tests
         # and use it for cache tests (silent login)

--- a/tests/NonInteractiveIntegration.Tests.ps1
+++ b/tests/NonInteractiveIntegration.Tests.ps1
@@ -1,0 +1,91 @@
+Describe 'Get-AzToken non-interactive integration tests' -Tag 'NonInteractive', 'Integration' {
+    BeforeDiscovery {
+        . "$BuildRoot\tests\cases\TestCases.ps1"
+        $NonInteractiveTestCases = Get-TestCaseByType -CaseType 'NonInteractiveTests'
+    }
+
+    BeforeAll {
+        function Get-UnsetRequiredEnvironmentVariable {
+            param(
+                [Parameter(Mandatory, Position = 0)]
+                [string[]]$VariableName
+            )
+
+            $UnsetVars = foreach ($Var in $VariableName) {
+                if (Test-Path "env:/$Var") { continue }
+                
+                Write-Output $Var
+            }
+
+            return $UnsetVars
+        }
+        # Ensure the environment variables are set
+        $UnsetVars = Get-UnsetRequiredEnvironmentVariable @('TENANT_ID', 'CLIENT_ID', 'CLIENT_SECRET', 'CLIENT_CERTIFICATE', 'CLIENT_CERTIFICATE_PRIVATE_KEY')
+
+        if ($UnsetVars.Count -gt 0) {
+            throw "Environment variable(s) must be set: $($UnsetVars -join ', ')"
+        }
+    }
+
+    # Tests is an array of hashtables with keys 'Splat', 'ExpectedScope', 'Flow', and 'Resource'
+    Context 'for flow <Flow>' -ForEach $NonInteractiveTestCases {
+        BeforeAll {
+            $TokenHash = @{
+                Token = $null
+                Now   = $null
+            }
+        }
+        BeforeEach {
+            # Ensure the environment variables are set
+            $UnsetVars = Get-UnsetRequiredEnvironmentVariable @('TENANT_ID', 'CLIENT_ID', 'CLIENT_SECRET', 'CLIENT_CERTIFICATE', 'CLIENT_CERTIFICATE_PRIVATE_KEY')
+
+            if ($UnsetVars.Count -gt 0) {
+                Set-ItResult -Inconclusive -Because "Environment variable(s) not set.)"
+            }
+        }
+
+        It 'gets a token for <Resource>' {
+            {
+                # Save the token, the current time, and the username
+                $TokenHash['Token'] = Get-AzToken @Splat
+                $TokenHash['Now'] = ([System.DateTimeOffset]::Now)
+            } | Should -Not -Throw
+
+            $TokenHash['Token'] | Should -Not -BeNullOrEmpty
+            $TokenHash['Token'].Token | Should -BeOfType [string]
+        }
+
+        It 'is for the correct identity' {
+            $TokenHash['Token'].Claims['appid'] | Should -Be $env:CLIENT_ID
+            # Identity is the object id of the service principal
+            $TokenHash['Token'].Identity -as [guid] | Should -BeOfType [guid]
+        }
+
+        It 'has the correct scope' {
+            $TokenHash['Token'].Scopes | Should -Contain $ExpectedScope
+        }
+
+        It 'has the correct resource' {
+            $TokenHash['Token'].Claims['aud'] | Should -Be $Splat['Resource']
+        }
+
+        It 'is valid' {
+            $TokenHash['Now'] -lt $TokenHash['Token'].ExpiresOn | Should -BeTrue
+        }
+
+        It 'has claims' {
+            $TokenHash['Token'].Claims | Should -Not -BeNullOrEmpty
+            $TokenHash['Token'].Claims.Count | Should -BeGreaterThan 1
+        }
+
+        AfterAll {
+            # If a token cache was created and used, clear it after the test
+            if ($Splat.ContainsKey('TokenCache') -and $Splat.ContainsKey('Username')) {
+                $script:CachesToRemove += $Splat['TokenCache']
+            }
+
+            # Clean up the token hash variable
+            Remove-Variable -Name TokenHash -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/tests/cases/TestCases.ps1
+++ b/tests/cases/TestCases.ps1
@@ -8,6 +8,7 @@ $CommonSplat = @{
 }
 
 # Define specific parameters for each authentication flow scenario
+# Make sure they're ordered to ensure consistent test execution
 $InteractiveAuthFlows = [ordered]@{
     'Interactive'            = @{
         Interactive   = $true

--- a/tests/cases/TestCases.ps1
+++ b/tests/cases/TestCases.ps1
@@ -1,115 +1,141 @@
-# Azure PowerShell Client ID
-$AzurePowerShellClientId = '1950a258-227b-4e31-a9cf-717495945fc2'
-
-# Define common parameters for all test cases
-$CommonSplat = @{
-    Tenant   = 'common'
-    ClientId = $AzurePowerShellClientId
-}
-
-# Define specific parameters for each authentication flow scenario
-# Make sure they're ordered to ensure consistent test execution
-$InteractiveAuthFlows = [ordered]@{
-    'Interactive'            = @{
-        Interactive   = $true
-        Resource      = 'https://graph.microsoft.com'
-        Scope         = @('.default')
-        ExpectedScope = 'openid'
-    }
-    'Interactive with Cache' = @{
-        Interactive   = $true
-        TokenCache    = 'IntegrationInteractiveTestCache'
-        Resource      = 'https://management.azure.com'
-        Scope         = @('.default')
-        ExpectedScope = 'https://management.azure.com/user_impersonation'
-    }
-    'Cache from Interactive' = @{
-        TokenCache    = 'IntegrationInteractiveTestCache'
-        Username      = '' # Will be set by the test
-        Resource      = 'cfa8b339-82a2-471a-a3c9-0fc0be7a4093' # Azure Key Vault
-        Scope         = @('.default')
-        ExpectedScope = 'cfa8b339-82a2-471a-a3c9-0fc0be7a4093/user_impersonation'
-    }
-    # 'Device Code'            = @{
-    #     DeviceCode = $true
-    # }
-    'Device Code with Cache' = @{
-        DeviceCode   = $true
-        TokenCache    = 'IntegrationDeviceCodeTestCache'
-        Resource      = 'https://storage.azure.com'
-        Scope         = @('.default')
-        ExpectedScope = 'https://storage.azure.com/user_impersonation'
-    }
-    'Cache from Device Code' = @{
-        TokenCache    = 'IntegrationDeviceCodeTestCache'
-        Username      = '' # Will be set by the test
-        Resource      = 'https://database.windows.net' # Azure SQL Database
-        Scope         = @('.default')
-        ExpectedScope = 'https://database.windows.net/.default'
-    }
-}
-
-# Generate test splatting hashtable based on test cases
-function Get-TestSplat {
+function New-ClientCertificateFromPem {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet(
-            'Interactive',
-            'Interactive with Cache',
-            'Cache from Interactive',
-            'Device Code',
-            'Device Code with Cache',
-            'Cache from Device Code'
-        )]
-        [string]$Flow
+        [string]$Certificate,
+
+        [Parameter(Mandatory)]
+        [string]$PrivateKey
     )
-    
-    $TestSplat = $CommonSplat.Clone()
-    # Transfer all parameters from the testcase to the splat
-    foreach ($AuthFlowKey in $InteractiveAuthFlows[$Flow].Keys) {
-        $TestSplat[$AuthFlowKey] = $InteractiveAuthFlows[$Flow][$AuthFlowKey]
+
+    try {
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromPem(
+            $Certificate,
+            $PrivateKey
+        )
     }
-    
-    return $TestSplat.Clone()
+    catch {
+        throw "Failed to create certificate object, did you set the environment variables correctly? Error: $_"
+    }
 }
 
 function Get-TestCaseByType {
     param(
         [Parameter(Mandatory)]
         [ValidateSet('InteractiveTests', 'NonInteractiveTests', 'CITests')]
-        [string[]]$CaseType
+        [string[]]$CaseType,
+
+        [Parameter()]
+        [string]$InteractiveClientId = '1950a258-227b-4e31-a9cf-717495945fc2' # Azure PowerShell Client ID
     )
 
-    $AuthFlows = [ordered]@{}
+    $TestCases = [ordered]@{}
 
     if ('InteractiveTests' -in $CaseType) {
         # Add interactive test cases
-        $AuthFlows += $InteractiveAuthFlows
-    }
-    if ('NonInteractiveTests' -in $CaseType) {
-        # Add non-interactive test cases
-        $AuthFlows += @{
+        $TestCases += [ordered]@{
+            'Interactive'            = @{
+                Tenant        = 'common'
+                ClientId      = $InteractiveClientId
+                Interactive   = $true
+                Resource      = 'https://graph.microsoft.com'
+                Scope         = @('.default')
+                ExpectedScope = 'openid'
+            }
+            'Interactive with Cache' = @{
+                Tenant        = 'common'
+                ClientId      = $InteractiveClientId
+                Interactive   = $true
+                TokenCache    = 'IntegrationInteractiveTestCache'
+                Resource      = 'https://management.azure.com'
+                Scope         = @('.default')
+                ExpectedScope = 'https://management.azure.com/user_impersonation'
+            }
+            'Cache from Interactive' = @{
+                Tenant        = 'common'
+                ClientId      = $InteractiveClientId
+                TokenCache    = 'IntegrationInteractiveTestCache'
+                Username      = '' # Will be set by the test
+                Resource      = 'cfa8b339-82a2-471a-a3c9-0fc0be7a4093' # Azure Key Vault
+                Scope         = @('.default')
+                ExpectedScope = 'cfa8b339-82a2-471a-a3c9-0fc0be7a4093/user_impersonation'
+            }
+            'Device Code with Cache' = @{
+                Tenant        = 'common'
+                ClientId      = $InteractiveClientId
+                DeviceCode    = $true
+                TokenCache    = 'IntegrationDeviceCodeTestCache'
+                Resource      = 'https://storage.azure.com'
+                Scope         = @('.default')
+                ExpectedScope = 'https://storage.azure.com/user_impersonation'
+            }
+            'Cache from Device Code' = @{
+                Tenant        = 'common'
+                ClientId      = $InteractiveClientId
+                TokenCache    = 'IntegrationDeviceCodeTestCache'
+                Username      = '' # Will be set by the test
+                Resource      = 'https://database.windows.net' # Azure SQL Database
+                Scope         = @('.default')
+                ExpectedScope = 'https://database.windows.net/.default'
+            }
         }
     }
-    if ('CITests' -in $CaseType) {
-        # Add CI tests (default)
-        $AuthFlows += @{
+    # if ('CITests' -in $CaseType) {
+    #     $TestCases += @{
+    #     }
+    # }
+    if ('NonInteractiveTests' -in $CaseType) {
+        # Create or resolve the PEM file path
+        $PemPath = try {
+            (New-Item -Name 'azauth.pem' -Value @"
+$env:CLIENT_CERTIFICATE
+$env:CLIENT_CERTIFICATE_PRIVATE_KEY
+"@).FullName
+        }
+        catch {
+            (Resolve-Path 'azauth.pem').Path
+        }
+
+        $TestCases += [ordered]@{
+            'Client Secret'      = @{
+                Tenant        = $env:TENANT_ID
+                ClientId      = $env:CLIENT_ID
+                ClientSecret  = $env:CLIENT_SECRET
+                Resource      = 'https://management.azure.com'
+                Scope         = @('.default')
+                ExpectedScope = 'https://management.azure.com/.default'
+            }
+            'Certificate Object' = @{
+                Tenant            = $env:TENANT_ID
+                ClientId          = $env:CLIENT_ID
+                ClientCertificate = New-ClientCertificateFromPem -Certificate $env:CLIENT_CERTIFICATE -PrivateKey $env:CLIENT_CERTIFICATE_PRIVATE_KEY
+                Resource          = 'https://graph.microsoft.com'
+                Scope             = @('.default')
+                ExpectedScope     = 'https://graph.microsoft.com/.default'
+            }
+            'Certificate Path'   = @{
+                Tenant                = $env:TENANT_ID
+                ClientId              = $env:CLIENT_ID
+                ClientCertificatePath = $PemPath
+                Resource              = 'https://storage.azure.com'
+                Scope                 = @('.default')
+                ExpectedScope         = 'https://storage.azure.com/.default'
+            }
         }
     }
 
-    foreach ($Flow in $AuthFlows.Keys) {
+    foreach ($Case in $TestCases.Keys) {
         # Get test splat for the current flow
-        $TestSplat = Get-TestSplat -Flow $Flow
+        $TestSplat = $TestCases[$Case]
         # Remove the expected scope from the splat to avoid passing it as a parameter
         $ExpectedScope = $TestSplat['ExpectedScope']
         $TestSplat.Remove('ExpectedScope')  # Remove ExpectedScope from splat
-        @(
-            @{
-                Splat         = $TestSplat
-                ExpectedScope = $ExpectedScope
-                Flow          = $Flow
-                Resource      = $TestSplat['Resource']
-            }
-        )
+
+        # Output the test case
+        @{
+            Splat         = $TestSplat
+            ExpectedScope = $ExpectedScope
+            Flow          = $Case
+            Resource      = $TestSplat['Resource']
+        }
     }
 }

--- a/tests/cases/TestCases.ps1
+++ b/tests/cases/TestCases.ps1
@@ -1,0 +1,168 @@
+# Azure PowerShell Client ID
+$AzurePowerShellClientId = '1950a258-227b-4e31-a9cf-717495945fc2'
+
+# Define authentication flows
+$AuthFlows = @(
+    @{
+        Name = 'Interactive'
+        Parameters = @{ Interactive = $true }
+        RequiresUserInteraction = $true
+        Tag = 'Interactive'
+    },
+    @{
+        Name = 'DeviceCode'
+        Parameters = @{ DeviceCode = $true }
+        RequiresUserInteraction = $true
+        Tag = 'Interactive'
+    },
+    @{
+        Name = 'ClientSecret'
+        Parameters = @{ 
+            ClientId = $env:AZURE_CLIENT_ID
+            ClientSecret = $env:AZURE_CLIENT_SECRET
+            TenantId = $env:AZURE_TENANT_ID
+        }
+        RequiresUserInteraction = $false
+        Tag = 'Integration'
+        RequiresSecrets = $true
+    },
+    @{
+        Name = 'ClientCertificate'
+        Parameters = @{
+            ClientId = $env:AZURE_CLIENT_ID
+            CertificatePath = $env:TEST_CERTIFICATE_PATH
+            TenantId = $env:AZURE_TENANT_ID
+        }
+        RequiresUserInteraction = $false
+        Tag = 'Integration'
+        RequiresSecrets = $true
+    },
+    @{
+        Name = 'ManagedIdentity'
+        Parameters = @{ ManagedIdentity = $true }
+        RequiresUserInteraction = $false
+        Tag = 'Integration'
+        RequiresAzureEnvironment = $true
+    }
+)
+
+# Define test resources with different scenarios
+$TestResources = @(
+    @{
+        Name = 'GraphDefault'
+        Resource = 'https://graph.microsoft.com'
+        Scopes = @('.default')
+        Description = 'Microsoft Graph API'
+        ExpectedAudience = 'https://graph.microsoft.com'
+    },
+    @{
+        Name = 'AzureResourceManager'
+        Resource = 'https://management.azure.com'
+        Scopes = @('.default')
+        Description = 'Azure Resource Manager'
+        ExpectedAudience = 'https://management.azure.com'
+    },
+    @{
+        Name = 'KeyVault'
+        Resource = 'https://vault.azure.net'
+        Scopes = @('.default')
+        Description = 'Azure Key Vault'
+        ExpectedAudience = 'https://vault.azure.net'
+    },
+    @{
+        Name = 'Storage'
+        Resource = 'https://storage.azure.com'
+        Scopes = @('.default')
+        Description = 'Azure Storage'
+        ExpectedAudience = 'https://storage.azure.com'
+    },
+    @{
+        Name = 'GraphSpecificScopes'
+        Resource = 'https://graph.microsoft.com'
+        Scopes = @('User.Read', 'Mail.Read')
+        Description = 'Microsoft Graph with specific scopes'
+        ExpectedAudience = 'https://graph.microsoft.com'
+    }
+)
+
+# Define tenant scenarios
+$TenantScenarios = @(
+    @{
+        Name = 'CommonTenant'
+        TenantId = 'common'
+        Description = 'Use default tenant'
+    },
+    @{
+        Name = 'SpecificTenant'
+        TenantId = $env:AZURE_TENANT_ID
+        Description = 'Use specific tenant ID'
+    }
+)
+
+# Generate test matrix combinations
+function Get-TestMatrix {
+    param(
+        [string[]]$IncludeFlows = @('Interactive', 'DeviceCode', 'ClientSecret', 'Certificate', 'ManagedIdentity'),
+        [string[]]$IncludeResources = @('MicrosoftGraph', 'AzureResourceManager'),
+        [string[]]$IncludeTenants = @('DefaultTenant'),
+        [string[]]$Tags = @()
+    )
+    
+    $TestCases = @()
+    
+    foreach ($flow in $AuthFlows | Where-Object { $_.Name -in $IncludeFlows }) {
+        foreach ($resource in $TestResources | Where-Object { $_.Name -in $IncludeResources }) {
+            foreach ($tenant in $TenantScenarios | Where-Object { $_.Name -in $IncludeTenants }) {
+                
+                # Skip combinations that don't make sense
+                if ($flow.RequiresSecrets -and -not $env:AZURE_CLIENT_ID) {
+                    continue
+                }
+                
+                if ($tenant.RequiresSecrets -and -not $env:AZURE_TENANT_ID) {
+                    continue
+                }
+                
+                if ($Tags.Count -gt 0 -and $flow.Tag -notin $Tags) {
+                    continue
+                }
+                
+                $testCase = @{
+                    TestName = "$($flow.Name)_$($resource.Name)_$($tenant.Name)"
+                    FlowName = $flow.Name
+                    ResourceName = $resource.Name
+                    TenantName = $tenant.Name
+                    
+                    # Auth parameters
+                    AuthParameters = $flow.Parameters.Clone()
+                    
+                    # Resource parameters
+                    Resource = $resource.Resource
+                    Scopes = $resource.Scopes
+                    ExpectedAudience = $resource.ExpectedAudience
+                    
+                    # Tenant parameters
+                    TenantId = $tenant.TenantId
+                    
+                    # Test metadata
+                    RequiresUserInteraction = $flow.RequiresUserInteraction
+                    RequiresSecrets = $flow.RequiresSecrets -or $tenant.RequiresSecrets
+                    RequiresAzureEnvironment = $flow.RequiresAzureEnvironment
+                    Tag = $flow.Tag
+                    
+                    # Description for test output
+                    Description = "Authenticate using $($flow.Name) for $($resource.Description) in $($tenant.Description)"
+                }
+                
+                # Add tenant ID to auth parameters if specified
+                if ($tenant.TenantId) {
+                    $testCase.AuthParameters.TenantId = $tenant.TenantId
+                }
+                
+                $TestCases += $testCase
+            }
+        }
+    }
+    
+    return $TestCases
+}

--- a/tests/interactive/Interactive.Tests.ps1
+++ b/tests/interactive/Interactive.Tests.ps1
@@ -1,0 +1,196 @@
+Describe 'Get-AzToken Interactive Tests' -Tag 'Interactive' {
+    BeforeDiscovery {
+        $CommonTestCases = . "$BuildRoot\tests\cases\TestCases.ps1"
+
+        $TestCases = $CommonTestCases
+    }
+
+    BeforeAll {
+        # These tests require user interaction and should only be run manually
+        Write-Warning "These tests require user interaction and will prompt for authentication."
+        Write-Warning "Press Ctrl+C to cancel if you don't want to authenticate interactively."
+    }
+
+    Context 'Interactive Authentication' -ForEach $TestCases {
+        It 'should authenticate interactively and return a valid token' {
+            Write-Host "This test will open a browser window for authentication..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -Interactive -Scope $TestScope
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.Scopes | Should -Contain $TestScope[0]
+            $Token.Username | Should -Not -BeNullOrEmpty
+            $Token.TenantId | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should authenticate interactively with custom resource' {
+            Write-Host "This test will open a browser window for authentication with custom resource..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -Interactive -Resource $TestResource
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.Username | Should -Not -BeNullOrEmpty
+            $Token.TenantId | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should authenticate interactively with specific tenant' {
+            Write-Host "This test will prompt for tenant ID and then open a browser window..." -ForegroundColor Yellow
+            
+            # Prompt for tenant ID for testing
+            $TenantId = Read-Host "Enter a tenant ID for testing (or press Enter to skip this test)"
+            
+            if ([string]::IsNullOrWhiteSpace($TenantId)) {
+                Set-ItResult -Skipped -Because "No tenant ID provided for testing"
+                return
+            }
+            
+            $Token = Get-AzToken -Interactive -Tenant $TenantId -Scope $TestScope
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.TenantId | Should -Be $TenantId
+        }
+    }
+
+    Context 'Device Code Authentication' {
+        It 'should authenticate with device code and return a valid token' {
+            Write-Host "This test will display a device code for authentication..." -ForegroundColor Yellow
+            Write-Host "You will need to open a browser and enter the provided code." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -DeviceCode -Scope $TestScope
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.Scopes | Should -Contain $TestScope[0]
+            $Token.Username | Should -Not -BeNullOrEmpty
+            $Token.TenantId | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should authenticate with device code using custom resource' {
+            Write-Host "This test will display a device code for authentication with custom resource..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -DeviceCode -Resource $TestResource
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.Username | Should -Not -BeNullOrEmpty
+            $Token.TenantId | Should -Not -BeNullOrEmpty
+        }
+
+        It 'should authenticate with device code for specific tenant' {
+            Write-Host "This test will prompt for tenant ID and then display a device code..." -ForegroundColor Yellow
+            
+            # Prompt for tenant ID for testing
+            $TenantId = Read-Host "Enter a tenant ID for device code testing (or press Enter to skip this test)"
+            
+            if ([string]::IsNullOrWhiteSpace($TenantId)) {
+                Set-ItResult -Skipped -Because "No tenant ID provided for testing"
+                return
+            }
+            
+            $Token = Get-AzToken -DeviceCode -Tenant $TenantId -Scope $TestScope
+            
+            # Verify token structure
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
+            $Token.TenantId | Should -Be $TenantId
+        }
+    }
+
+    Context 'Cache Integration with Interactive Authentication' {
+        BeforeAll {
+            $TestCacheName = "InteractiveTestCache_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+        }
+
+        AfterAll {
+            # Cleanup test cache
+            try {
+                Clear-AzTokenCache -TokenCache $TestCacheName -ErrorAction SilentlyContinue
+            }
+            catch {
+                Write-Warning "Could not clean up test cache '$($TestCacheName)': $($_.Exception.Message)"
+            }
+        }
+
+        It 'should create cache during interactive authentication' {
+            Write-Host "This test will authenticate interactively and create a cache..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -Interactive -TokenCache $TestCacheName -Scope $TestScope
+            
+            # Verify token
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            
+            # Verify cache was created by trying to get token from cache
+            $CachedToken = Get-AzToken -TokenCache $TestCacheName -Username $Token.Username -Scope $TestScope
+            $CachedToken | Should -Not -BeNullOrEmpty
+            $CachedToken.Username | Should -Be $Token.Username
+        }
+
+        It 'should create cache during device code authentication' {
+            Write-Host "This test will authenticate with device code and create a cache..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -DeviceCode -TokenCache $TestCacheName -Scope $TestScope
+            
+            # Verify token
+            $Token | Should -Not -BeNullOrEmpty
+            $Token.AccessToken | Should -Not -BeNullOrEmpty
+            
+            # Verify cache was created by trying to get token from cache
+            $CachedToken = Get-AzToken -TokenCache $TestCacheName -Username $Token.Username -Scope $TestScope
+            $CachedToken | Should -Not -BeNullOrEmpty
+            $CachedToken.Username | Should -Be $Token.Username
+        }
+    }
+
+    Context 'Token Properties Validation' {
+        It 'should return token with valid claims from interactive auth' {
+            Write-Host "This test will authenticate interactively to validate token claims..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -Interactive -Scope $TestScope
+            
+            # Verify token has expected properties
+            $Token.PSObject.Properties.Name | Should -Contain 'AccessToken'
+            $Token.PSObject.Properties.Name | Should -Contain 'Scopes'
+            $Token.PSObject.Properties.Name | Should -Contain 'ExpiresOn'
+            $Token.PSObject.Properties.Name | Should -Contain 'Claims'
+            $Token.PSObject.Properties.Name | Should -Contain 'Username'
+            $Token.PSObject.Properties.Name | Should -Contain 'TenantId'
+            
+            # Verify claims exist and contain expected values
+            $Token.Claims | Should -Not -BeNullOrEmpty
+            $Token.Claims.Count | Should -BeGreaterThan 0
+        }
+
+        It 'should return token with valid claims from device code auth' {
+            Write-Host "This test will authenticate with device code to validate token claims..." -ForegroundColor Yellow
+            
+            $Token = Get-AzToken -DeviceCode -Scope $TestScope
+            
+            # Verify token has expected properties
+            $Token.PSObject.Properties.Name | Should -Contain 'AccessToken'
+            $Token.PSObject.Properties.Name | Should -Contain 'Scopes'
+            $Token.PSObject.Properties.Name | Should -Contain 'ExpiresOn'
+            $Token.PSObject.Properties.Name | Should -Contain 'Claims'
+            $Token.PSObject.Properties.Name | Should -Contain 'Username'
+            $Token.PSObject.Properties.Name | Should -Contain 'TenantId'
+            
+            # Verify claims exist and contain expected values
+            $Token.Claims | Should -Not -BeNullOrEmpty
+            $Token.Claims.Count | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/tests/interactive/Interactive.Tests.ps1
+++ b/tests/interactive/Interactive.Tests.ps1
@@ -1,196 +1,85 @@
-Describe 'Get-AzToken Interactive Tests' -Tag 'Interactive' {
-    BeforeDiscovery {
-        $CommonTestCases = . "$BuildRoot\tests\cases\TestCases.ps1"
+BeforeDiscovery {
+    # These tests require user interaction and should only be run manually
+    Write-Host @'
+These tests require user interaction and will prompt for authentication.
+The tokens acquired in the integration tests are real, and should be handled as secrets!
+'@
 
-        $TestCases = $CommonTestCases
-    }
+    . "$BuildRoot\tests\cases\TestCases.ps1"
+    $InteractiveTestCases = Get-TestCaseByType -CaseType 'InteractiveTests'
+}
 
+BeforeAll {
+    $script:CachesToRemove = @()
+}
+
+Describe 'Get-AzToken interactive tests' -Tag 'Interactive' {
     BeforeAll {
-        # These tests require user interaction and should only be run manually
-        Write-Warning "These tests require user interaction and will prompt for authentication."
-        Write-Warning "Press Ctrl+C to cancel if you don't want to authenticate interactively."
+        # Create a variable to hold the last username used
+        # This allows us to save the username used in interactive tests
+        # and use it for cache tests (silent login)
+        $script:LastUsername = $null
     }
 
-    Context 'Interactive Authentication' -ForEach $TestCases {
-        It 'should authenticate interactively and return a valid token' {
-            Write-Host "This test will open a browser window for authentication..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -Interactive -Scope $TestScope
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.Scopes | Should -Contain $TestScope[0]
-            $Token.Username | Should -Not -BeNullOrEmpty
-            $Token.TenantId | Should -Not -BeNullOrEmpty
-        }
-
-        It 'should authenticate interactively with custom resource' {
-            Write-Host "This test will open a browser window for authentication with custom resource..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -Interactive -Resource $TestResource
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.Username | Should -Not -BeNullOrEmpty
-            $Token.TenantId | Should -Not -BeNullOrEmpty
-        }
-
-        It 'should authenticate interactively with specific tenant' {
-            Write-Host "This test will prompt for tenant ID and then open a browser window..." -ForegroundColor Yellow
-            
-            # Prompt for tenant ID for testing
-            $TenantId = Read-Host "Enter a tenant ID for testing (or press Enter to skip this test)"
-            
-            if ([string]::IsNullOrWhiteSpace($TenantId)) {
-                Set-ItResult -Skipped -Because "No tenant ID provided for testing"
-                return
-            }
-            
-            $Token = Get-AzToken -Interactive -Tenant $TenantId -Scope $TestScope
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.TenantId | Should -Be $TenantId
-        }
-    }
-
-    Context 'Device Code Authentication' {
-        It 'should authenticate with device code and return a valid token' {
-            Write-Host "This test will display a device code for authentication..." -ForegroundColor Yellow
-            Write-Host "You will need to open a browser and enter the provided code." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -DeviceCode -Scope $TestScope
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.Scopes | Should -Contain $TestScope[0]
-            $Token.Username | Should -Not -BeNullOrEmpty
-            $Token.TenantId | Should -Not -BeNullOrEmpty
-        }
-
-        It 'should authenticate with device code using custom resource' {
-            Write-Host "This test will display a device code for authentication with custom resource..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -DeviceCode -Resource $TestResource
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.Username | Should -Not -BeNullOrEmpty
-            $Token.TenantId | Should -Not -BeNullOrEmpty
-        }
-
-        It 'should authenticate with device code for specific tenant' {
-            Write-Host "This test will prompt for tenant ID and then display a device code..." -ForegroundColor Yellow
-            
-            # Prompt for tenant ID for testing
-            $TenantId = Read-Host "Enter a tenant ID for device code testing (or press Enter to skip this test)"
-            
-            if ([string]::IsNullOrWhiteSpace($TenantId)) {
-                Set-ItResult -Skipped -Because "No tenant ID provided for testing"
-                return
-            }
-            
-            $Token = Get-AzToken -DeviceCode -Tenant $TenantId -Scope $TestScope
-            
-            # Verify token structure
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            $Token.ExpiresOn | Should -BeGreaterThan (Get-Date)
-            $Token.TenantId | Should -Be $TenantId
-        }
-    }
-
-    Context 'Cache Integration with Interactive Authentication' {
+    # Tests is an array of hashtables with keys 'Splat', 'ExpectedScope', 'Flow', and 'Resource'
+    Context 'for flow <Flow>' -ForEach $InteractiveTestCases {
         BeforeAll {
-            $TestCacheName = "InteractiveTestCache_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+            $TokenHash = @{
+                Token = $null
+                Now   = $null
+            }
+        }
+
+        It 'gets a token for <Resource>' {
+            {
+                # If the splat contains a username, it's a cache test
+                # In that case, set it to the last username used
+                if ($Splat.ContainsKey('Username')) {
+                    $Splat['Username'] = $script:LastUsername
+                }
+
+                # Save the token, the current time, and the username
+                $TokenHash['Token'] = Get-AzToken @Splat
+                $TokenHash['Now'] = ([System.DateTimeOffset]::Now)
+                $script:LastUsername = $TokenHash['Token'].Identity
+            } | Should -Not -Throw
+
+            $TokenHash['Token'] | Should -Not -BeNullOrEmpty
+            $TokenHash['Token'].Token | Should -BeOfType [string]
+        }
+
+        It 'has the correct scope' {
+            $TokenHash['Token'].Scopes | Should -Contain $ExpectedScope
+        }
+
+        It 'has the correct resource' {
+            $TokenHash['Token'].Claims['aud'] | Should -Be $Splat['Resource']
+        }
+
+        It 'is valid' {
+            $TokenHash['Now'] -lt $TokenHash['Token'].ExpiresOn | Should -BeTrue
+        }
+
+        It 'has claims' {
+            $TokenHash['Token'].Claims | Should -Not -BeNullOrEmpty
+            $TokenHash['Token'].Claims.Count | Should -BeGreaterThan 1
         }
 
         AfterAll {
-            # Cleanup test cache
-            try {
-                Clear-AzTokenCache -TokenCache $TestCacheName -ErrorAction SilentlyContinue
+            # If a token cache was created and used, clear it after the test
+            if ($Splat.ContainsKey('TokenCache') -and $Splat.ContainsKey('Username')) {
+                $script:CachesToRemove += $Splat['TokenCache']
             }
-            catch {
-                Write-Warning "Could not clean up test cache '$($TestCacheName)': $($_.Exception.Message)"
-            }
-        }
 
-        It 'should create cache during interactive authentication' {
-            Write-Host "This test will authenticate interactively and create a cache..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -Interactive -TokenCache $TestCacheName -Scope $TestScope
-            
-            # Verify token
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            
-            # Verify cache was created by trying to get token from cache
-            $CachedToken = Get-AzToken -TokenCache $TestCacheName -Username $Token.Username -Scope $TestScope
-            $CachedToken | Should -Not -BeNullOrEmpty
-            $CachedToken.Username | Should -Be $Token.Username
-        }
-
-        It 'should create cache during device code authentication' {
-            Write-Host "This test will authenticate with device code and create a cache..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -DeviceCode -TokenCache $TestCacheName -Scope $TestScope
-            
-            # Verify token
-            $Token | Should -Not -BeNullOrEmpty
-            $Token.AccessToken | Should -Not -BeNullOrEmpty
-            
-            # Verify cache was created by trying to get token from cache
-            $CachedToken = Get-AzToken -TokenCache $TestCacheName -Username $Token.Username -Scope $TestScope
-            $CachedToken | Should -Not -BeNullOrEmpty
-            $CachedToken.Username | Should -Be $Token.Username
+            # Clean up the token hash variable
+            Remove-Variable -Name TokenHash -ErrorAction SilentlyContinue
         }
     }
+}
 
-    Context 'Token Properties Validation' {
-        It 'should return token with valid claims from interactive auth' {
-            Write-Host "This test will authenticate interactively to validate token claims..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -Interactive -Scope $TestScope
-            
-            # Verify token has expected properties
-            $Token.PSObject.Properties.Name | Should -Contain 'AccessToken'
-            $Token.PSObject.Properties.Name | Should -Contain 'Scopes'
-            $Token.PSObject.Properties.Name | Should -Contain 'ExpiresOn'
-            $Token.PSObject.Properties.Name | Should -Contain 'Claims'
-            $Token.PSObject.Properties.Name | Should -Contain 'Username'
-            $Token.PSObject.Properties.Name | Should -Contain 'TenantId'
-            
-            # Verify claims exist and contain expected values
-            $Token.Claims | Should -Not -BeNullOrEmpty
-            $Token.Claims.Count | Should -BeGreaterThan 0
-        }
-
-        It 'should return token with valid claims from device code auth' {
-            Write-Host "This test will authenticate with device code to validate token claims..." -ForegroundColor Yellow
-            
-            $Token = Get-AzToken -DeviceCode -Scope $TestScope
-            
-            # Verify token has expected properties
-            $Token.PSObject.Properties.Name | Should -Contain 'AccessToken'
-            $Token.PSObject.Properties.Name | Should -Contain 'Scopes'
-            $Token.PSObject.Properties.Name | Should -Contain 'ExpiresOn'
-            $Token.PSObject.Properties.Name | Should -Contain 'Claims'
-            $Token.PSObject.Properties.Name | Should -Contain 'Username'
-            $Token.PSObject.Properties.Name | Should -Contain 'TenantId'
-            
-            # Verify claims exist and contain expected values
-            $Token.Claims | Should -Not -BeNullOrEmpty
-            $Token.Claims.Count | Should -BeGreaterThan 0
-        }
+AfterAll {
+    foreach ($Cache in $script:CachesToRemove) {
+        Clear-AzTokenCache -TokenCache $Cache -Force
     }
+    Remove-Variable -Name CachesToRemove -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
# Pull Request

### Added

- Integration tests for interactive auth flows with caching
- Integration tests for client credentials flows
- Added cache name in warning when removing cache with `Clear-AzTokenCache -Force`

---

Not including tests for Workload Identity or Broker (WAM) flows.