### PR TITLE
fix: Update ModuleBuilder configuration: set SourcePath to 'source' and define BuiltModuleSubdirectory as 'module'

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,7 +10,7 @@
     InvokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
     Pester                      = 'latest'
-    ModuleBuilder               = 'latest'
+    ModuleBuilder               = '3.1.8' # pinned: 3.2+ breaks SourcePath validation for binary modules
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
     'Sampler.GitHubTasks'       = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,8 @@
 #          ModuleBuilder Configuration             #
 ####################################################
 # Path to the Module Manifest to build (where path will be resolved from)
-SourcePath: ../source/AzAuth.psd1
+SourcePath: source
+BuiltModuleSubdirectory: module
 # Output Directory where ModuleBuilder will build the Module, relative to module manifest
 OutputDirectory: ../../output/AzAuth
 # BuiltModuleSubdirectory: module


### PR DESCRIPTION
# Pull Request

Fixes source path for Sampler.
